### PR TITLE
Fix tests and remember closing time

### DIFF
--- a/tests/templates/fund.template.js
+++ b/tests/templates/fund.template.js
@@ -43,7 +43,7 @@ checkWork();
 console.log("Wait for end of sale");
 setTimeout(function() {
     miner.stop(0);
-    console.log("CHECK(dao.funded): " + dao.funded());
+    console.log("CHECK(dao.funded): " + dao.isFunded());
     console.log("CHECK(dao.totalSupply): " + web3.fromWei(dao.totalSupply()));
     for (i = 0; i < eth.accounts.length; i++) {
         console.log("CHECK(balanceuser" + i +"): " + web3.fromWei(dao.balanceOf(eth.accounts[i])));


### PR DESCRIPTION
- Fix tests after the latest contract changes

- If using an already deployed DAO contract, remember the closing time
  so that the fund scenario can wait for the required time. Also pring
  warning so that the user knows how much time it will take