### PR TITLE
Claiming Rewards for Token holders scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tests/deploy.js
 tests/fund.js
 tests/proposal.js
 tests/accounts.js
+tests/rewards.js
 
 # python metadata in tests
 tests/*.pyc

--- a/tests/args.py
+++ b/tests/args.py
@@ -78,8 +78,15 @@ def test_args():
         default=5
     )
     p.add_argument(
+        '--total-rewards',
+        type=int,
+        help='Amount of ether a kind soul will donate to the DAO'
+        ' for the rewards scenario.',
+        default=78
+    )
+    p.add_argument(
         '--scenario',
-        choices=['none', 'deploy', 'fund', 'proposal'],
+        choices=['none', 'deploy', 'fund', 'proposal', 'rewards'],
         default='none',
         help='Test scenario to play out'
     )

--- a/tests/templates/rewards.template.js
+++ b/tests/templates/rewards.template.js
@@ -1,0 +1,73 @@
+var dao = web3.eth.contract($dao_abi).at('$dao_address');
+
+// some kind soul makes a donation to the DAO, so rewards get populated
+console.log("Donating to DAO...");
+dao.payDAO.sendTransaction({
+    from: eth.accounts[1],
+    value: web3.toWei($total_rewards, "ether"),
+    gas: 100000
+});
+checkWork();
+
+// create a new proposal for sending this whole donation to the rewardAccount
+console.log("Creating proposal to send to rewardAccount...");
+var tx_hash = null;
+dao.newProposal.sendTransaction(
+    dao.rewardAccount(),
+    web3.toWei($total_rewards, "ether"),
+    'Send money to the reward account',
+    '$transaction_bytecode', // bytecode, not needed here, calling the fallback function
+    $debating_period,
+    false,
+    {
+        from: proposalCreator,
+        value: web3.toWei($proposal_deposit, "ether"),
+        gas: 1000000
+    }
+    , function (e, res) {
+        if (e) {
+            console.log(e + "at newProposal()!");
+        } else {
+            tx_hash = res;
+            console.log("newProposal tx hash is: " + tx_hash);
+        }
+    }
+);
+checkWork();
+
+
+var prop_id = $prop_id;
+console.log("Voting for proposal '" + prop_id + "' ...");
+// in this scenario let's just say everyone votes 100% in favour
+for (i = 0; i < eth.accounts.length; i++) {
+    dao.vote.sendTransaction(
+        prop_id,
+        true,
+        {
+            from: eth.accounts[i],
+            gas: 1000000
+        }
+    );
+}
+checkWork();
+
+setTimeout(function() {
+    miner.stop(0);
+    console.log("Executing the proposal...");
+    // now execute the proposal
+    dao.executeProposal.sendTransaction(prop_id, '$transaction_bytecode', {from:serviceProvider, gas:1000000});
+    checkWork();
+    addToTest('provider_balance_before_claim', web3.fromWei(eth.getBalance(serviceProvider)));
+    console.log("Claiming the reward...");
+    dao.getMyReward.sendTransaction({from: serviceProvider, gas: 1000000});
+    checkWork();
+    addToTest('provider_balance_after_claim', web3.fromWei(eth.getBalance(serviceProvider)));
+    addToTest(
+        'provider_reward_portion',
+        bigDiff(
+            testMap['provider_balance_after_claim'], testMap['provider_balance_before_claim']
+        )
+    );
+    testResults();
+}, $debating_period * 1000);
+console.log("Wait for end of debating period");

--- a/tests/test.py
+++ b/tests/test.py
@@ -92,23 +92,39 @@ class TestContext():
         rm_file(os.path.join(data_dir, "saved"))
 
     def run_script(self, script):
-        print("Running '{}' script".format(script))
-        return subprocess.check_output([
-            self.geth,
-            "--networkid",
-            "123",
-            "--nodiscover",
-            "--maxpeers",
-            "0",
-            "--genesis",
-            "./genesis_block.json",
-            "--datadir",
-            "./data",
-            "--verbosity",
-            "0",
-            "js",
-            script
-        ])
+        if script == 'accounts.js':
+            return subprocess.check_output([
+                self.geth,
+                "--networkid",
+                "123",
+                "--nodiscover",
+                "--maxpeers",
+                "0",
+                "--datadir",
+                "./data",
+                "--verbosity",
+                "0",
+                "js",
+                script
+            ])
+        else:
+            print("Running '{}' script".format(script))
+            return subprocess.check_output([
+                self.geth,
+                "--networkid",
+                "123",
+                "--nodiscover",
+                "--maxpeers",
+                "0",
+                "--genesis",
+                "./genesis_block.json",
+                "--datadir",
+                "./data",
+                "--verbosity",
+                "0",
+                "js",
+                script
+            ])
 
     def compile_contract(self, contract_path):
         print("    Compiling {}...".format(contract_path))
@@ -253,9 +269,9 @@ class TestContext():
             )
 
         sale_secs = self.closing_time - ts_now()
-        total_amount = self.min_value + random.randint(1, 100)
+        self.total_supply = self.min_value + random.randint(1, 100)
         self.token_amounts = constrained_sum_sample_pos(
-            len(self.accounts), total_amount
+            len(self.accounts), self.total_supply
         )
         self.create_fund_js(sale_secs, self.token_amounts)
         print(
@@ -265,7 +281,7 @@ class TestContext():
         output = self.run_script('fund.js')
         eval_test('fund.js', output, {
             "dao_funded": True,
-            "total_supply": total_amount,
+            "total_supply": self.total_supply,
             "balances": self.token_amounts,
             "user0_after": self.token_amounts[0],
         })

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ import random
 import os
 import json
 import sys
+import math
 from datetime import datetime
 from jsutils import js_common_intro
 
@@ -156,3 +157,7 @@ def count_token_votes(amounts, votes):
         else:
             nay += amount
     return yay, nay
+
+
+def calculate_reward(tokens, total_tokens, total_rewards):
+    return math.ceil((tokens * total_rewards) / total_tokens)


### PR DESCRIPTION
- Adding a new scenario, the rewards scenario

- proposal ids are now counted on the python side

- The scenario continues off after the normal proposal scenario, makes a
  proposal to move funds to the rewards account of the DAO and then a
  single token holder attempts to get his portion of the rewards. The
  test asserts he gets the exact share expected

- Fixed an error where, absence of genesis block throws python exception.