### PR TITLE
Hopefully last big style fix PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tests/fund.js
 tests/proposal.js
 tests/accounts.js
 tests/rewards.js
+tests/split.js
 
 # python metadata in tests
 tests/*.pyc

--- a/DAO.sol
+++ b/DAO.sol
@@ -172,9 +172,7 @@ contract DAOInterface {
         bytes _transactionData, 
         uint _debatingPeriod, 
         bool _newServiceProvider
-    ) 
-        onlyTokenholders 
-        returns (uint _proposalID);
+    ) onlyTokenholders returns (uint _proposalID);
 
     /// @notice Check that the proposal with the ID `_proposalID` matches the 
     /// transaction which sends `_amount` with data `_transactionData` 
@@ -189,17 +187,16 @@ contract DAOInterface {
         address _recipient, 
         uint _amount, 
         bytes _transactionData
-    ) 
-        constant 
-        returns (bool _codeChecksOut);
+    ) constant returns (bool _codeChecksOut);
 
     /// @notice Vote on proposal `_proposalID` with `_supportsProposal`
     /// @param _proposalID The proposal ID
     /// @param _supportsProposal Yes/No - support of the proposal
     /// @return The vote ID.
-    function vote(uint _proposalID, bool _supportsProposal) 
-        onlyTokenholders 
-        returns (uint _voteID);
+    function vote(
+        uint _proposalID,
+        bool _supportsProposal
+    ) onlyTokenholders returns (uint _voteID);
 
     /// @notice Checks whether proposal `_proposalID` with transaction data 
     /// `_transactionData` has been voted for or rejected, and executes the 
@@ -207,8 +204,10 @@ contract DAOInterface {
     /// @param _proposalID The proposal ID
     /// @param _transactionData The data of the proposed transaction
     /// @return Whether the proposed transaction has been executed or not
-    function executeProposal(uint _proposalID, bytes _transactionData) 
-        returns (bool _success);
+    function executeProposal(
+        uint _proposalID,
+        bytes _transactionData
+    ) returns (bool _success);
 
     /// @notice ATTENTION! I confirm to move my remaining funds to a new DAO 
     /// with `_newServiceProvider` as the new service provider, as has been 
@@ -224,16 +223,13 @@ contract DAOInterface {
     function splitDAO(
         uint _proposalID, 
         address _newServiceProvider
-    ) 
-        returns (bool _success);
+    ) returns (bool _success);
 
     /// @notice Add a new possible recipient `_recipient` to the whitelist so 
     /// that the DAO can send transactions to them (using proposals)
     /// @param _recipient New recipient address
     /// @dev Can only be called by the current service provider
-    function addAllowedAddress(address _recipient) 
-        external 
-        returns (bool _success);
+    function addAllowedAddress(address _recipient) external returns (bool _success);
 
     /// @notice Change the minimum deposit required to submit a proposal 
     /// @param _proposalDeposit The new proposal deposit
@@ -255,8 +251,7 @@ contract DAOInterface {
     /// @param _to The address of the recipient
     /// @param _amount The amount of tokens to be transfered
     /// @return Whether the transfer was successful or not
-    function transferWithoutReward(address _to, uint256 _amount) 
-        returns (bool success);
+    function transferWithoutReward(address _to, uint256 _amount) returns (bool success);
 
     /// @notice Send `_amount` tokens to `_to` from `_from` on the condition it 
     /// is approved by `_from`. Prior to this getMyReward() is called.
@@ -268,8 +263,7 @@ contract DAOInterface {
         address _from, 
         address _to, 
         uint256 _amount
-    ) 
-        returns (bool success);
+    ) returns (bool success);
 
     /// @notice Doubles the 'minQuorumDivisor' in the case quorum has not been 
     /// achieved in 52 weeks
@@ -305,9 +299,8 @@ contract DAO is DAOInterface, Token, TokenSale {
         uint _minValue, 
         uint _closingTime, 
         address _privateSale
-    ) 
-        TokenSale(_minValue, _closingTime, _privateSale) 
-    {
+    ) TokenSale(_minValue, _closingTime, _privateSale) {
+
         serviceProvider = _defaultServiceProvider;
         daoCreator = _daoCreator;
         proposalDeposit = 20 ether;
@@ -343,10 +336,8 @@ contract DAO is DAOInterface, Token, TokenSale {
         bytes _transactionData, 
         uint _debatingPeriod, 
         bool _newServiceProvider
-    ) 
-        onlyTokenholders 
-        returns (uint _proposalID)
-    {
+    ) onlyTokenholders returns (uint _proposalID) {
+
         // Sanity check
         if (_newServiceProvider && (
             _amount != 0 
@@ -401,21 +392,17 @@ contract DAO is DAOInterface, Token, TokenSale {
         address _recipient, 
         uint _amount, 
         bytes _transactionData
-    ) 
-        noEther 
-        constant 
-        returns (bool _codeChecksOut) 
-    {
+    ) noEther constant returns (bool _codeChecksOut) {
         Proposal p = proposals[_proposalID];
         return p.proposalHash == sha3(_recipient, _amount, _transactionData);
     }
 
 
-    function vote(uint _proposalID, bool _supportsProposal) 
-        onlyTokenholders 
-        noEther 
-        returns (uint _voteID) 
-    {
+    function vote(
+        uint _proposalID,
+        bool _supportsProposal
+    ) onlyTokenholders noEther returns (uint _voteID) {
+
         Proposal p = proposals[_proposalID];
         if (p.votedYes[msg.sender] 
             || p.votedNo[msg.sender] 
@@ -445,10 +432,11 @@ contract DAO is DAOInterface, Token, TokenSale {
     }
 
 
-    function executeProposal(uint _proposalID, bytes _transactionData) 
-        noEther 
-        returns (bool _success) 
-    {
+    function executeProposal(
+        uint _proposalID,
+        bytes _transactionData
+    ) noEther returns (bool _success) {
+
         Proposal p = proposals[_proposalID];
         // Check if the proposal can be executed
         if (now < p.votingDeadline  // has the voting deadline arrived?
@@ -458,7 +446,7 @@ contract DAO is DAOInterface, Token, TokenSale {
             || p.proposalHash != sha3(p.recipient, p.amount, _transactionData)) 
             throw;
 
-        if (p.newServiceProvider){
+        if (p.newServiceProvider) {
             p.open = false;
             return;
         }
@@ -498,11 +486,11 @@ contract DAO is DAOInterface, Token, TokenSale {
     }
 
 
-    function splitDAO(uint _proposalID, address _newServiceProvider) 
-        noEther 
-        onlyTokenholders 
-        returns (bool _success) 
-    {
+    function splitDAO(
+        uint _proposalID,
+        address _newServiceProvider
+    ) noEther onlyTokenholders returns (bool _success) {
+
         Proposal p = proposals[_proposalID];
 
         // Sanity check
@@ -592,16 +580,13 @@ contract DAO is DAOInterface, Token, TokenSale {
     }
 
 
-    function transferWithoutReward(address _to, uint256 _value) 
-        returns (bool success) 
-    {
+    function transferWithoutReward(address _to, uint256 _value) returns (bool success) {
         if (!getMyReward()) throw;
         return transfer(_to, _value);
     }
 
 
-    function transferFrom(address _from, address _to, uint256 _value) 
-        returns (bool success) 
+    function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {
     {
         if (isFunded 
             && now > closingTime 
@@ -619,18 +604,19 @@ contract DAO is DAOInterface, Token, TokenSale {
         address _from, 
         address _to, 
         uint256 _value
-    ) 
-        returns (bool success) 
-    {
+    ) returns (bool success) {
+
         if (!withdrawRewardFor(_from)) throw;
         return transferFrom(_from, _to, _value);
     }
 
 
-    function transferPaidOut(address _from, address _to, uint256 _value) 
-        internal 
-        returns (bool success) 
-    {
+    function transferPaidOut(
+        address _from,
+        address _to,
+        uint256 _value
+    ) internal returns (bool success) {
+
         uint transferPaidOut = paidOut[_from] * _value / balanceOf(_from);
         if (transferPaidOut > paidOut[_from]) throw;
         paidOut[_from] -= transferPaidOut;
@@ -646,21 +632,14 @@ contract DAO is DAOInterface, Token, TokenSale {
     }
 
 
-    function addAllowedAddress(address _recipient) 
-        noEther 
-        external 
-        returns (bool _success) 
-    {
+    function addAllowedAddress(address _recipient) noEther external returns (bool _success) {
         if (msg.sender != serviceProvider) throw;
         allowedRecipients.push(_recipient);
         return true;
     }
 
 
-    function isRecipientAllowed(address _recipient) 
-        internal 
-        returns (bool _isAllowed) 
-    {
+    function isRecipientAllowed(address _recipient) internal returns (bool _isAllowed) {
         if (_recipient == serviceProvider 
             || _recipient == address(rewardAccount) 
             || _recipient == address(this)
@@ -695,10 +674,7 @@ contract DAO is DAOInterface, Token, TokenSale {
     }
 
 
-    function createNewDAO(address _newServiceProvider) 
-        internal 
-        returns (DAO _newDAO) 
-    {
+    function createNewDAO(address _newServiceProvider) internal returns (DAO _newDAO) {
         NewServiceProvider(_newServiceProvider);
         return daoCreator.createDAO(_newServiceProvider, 0, now + 42 days);
     }
@@ -727,9 +703,8 @@ contract DAO_Creator {
         address _defaultServiceProvider, 
         uint _minValue, 
         uint _closingTime
-    ) 
-        returns (DAO _newDAO) 
-    {
+    ) returns (DAO _newDAO) {
+
         return new DAO(
             _defaultServiceProvider, 
             DAO_Creator(this), 

--- a/DAO.sol
+++ b/DAO.sol
@@ -308,7 +308,8 @@ contract DAO is DAOInterface, Token, TokenSale {
         lastTimeMinQuorumMet = now;
         minQuorumDivisor = 5; // sets the minimal quorum to 20%
         proposals.length++; // avoids a proposal with ID 0 because it is used
-        if (address(rewardAccount) == 0) throw;
+        if (address(rewardAccount) == 0)
+            throw;
     }
 
     function () returns (bool success) {
@@ -355,9 +356,10 @@ contract DAO is DAOInterface, Token, TokenSale {
 
         if (!isFunded
             || now < closingTime
-            || (msg.value < proposalDeposit && !_newServiceProvider)
-        )
+            || (msg.value < proposalDeposit && !_newServiceProvider)) {
+
             throw;
+        }
 
         if (_recipient == address(rewardAccount) && _amount > rewards)
             throw;
@@ -408,10 +410,12 @@ contract DAO is DAOInterface, Token, TokenSale {
         Proposal p = proposals[_proposalID];
         if (p.votedYes[msg.sender]
             || p.votedNo[msg.sender]
-            || now >= p.votingDeadline)
-            throw;
+            || now >= p.votingDeadline) {
 
-        if (_supportsProposal){
+            throw;
+        }
+
+        if (_supportsProposal) {
             p.yea += balances[msg.sender];
             p.votedYes[msg.sender] = true;
         } else {
@@ -442,8 +446,10 @@ contract DAO is DAOInterface, Token, TokenSale {
             // Have the votes been counted?
             || !p.open
             // Does the transaction code match the proposal?
-            || p.proposalHash != sha3(p.recipient, p.amount, _transactionData))
+            || p.proposalHash != sha3(p.recipient, p.amount, _transactionData)) {
+
             throw;
+        }
 
         if (p.newServiceProvider) {
             p.open = false;
@@ -454,24 +460,28 @@ contract DAO is DAOInterface, Token, TokenSale {
 
         // Execute result
         if (quorum >= minQuorum(p.amount) && p.yea > p.nay) {
-            if (!p.creator.send(p.proposalDeposit)) throw;
+            if (!p.creator.send(p.proposalDeposit))
+                throw;
             // Without this throw, the creator of the proposal can repeat this,
             // and get so much ether
-            if (!p.recipient.call.value(p.amount)(_transactionData)) throw;
+            if (!p.recipient.call.value(p.amount)(_transactionData))
+                throw;
             p.proposalPassed = true;
             _success = true;
             lastTimeMinQuorumMet = now;
             if (p.recipient == address(rewardAccount)) {
                 // This happens when multiple similar proposals are created and
                 // both are passed at the same time.
-                if (rewards < p.amount) throw;
+                if (rewards < p.amount)
+                    throw;
                 rewards -= p.amount;
             } else {
                 rewardToken[address(this)] += p.amount;
                 totalRewardToken += p.amount;
             }
         } else if (quorum >= minQuorum(p.amount) && p.nay >= p.yea) {
-            if (!p.creator.send(p.proposalDeposit)) throw;
+            if (!p.creator.send(p.proposalDeposit))
+                throw;
             lastTimeMinQuorumMet = now;
         }
 
@@ -502,8 +512,10 @@ contract DAO is DAOInterface, Token, TokenSale {
             // Have you voted for this split?
             || !p.votedYes[msg.sender]
             // Did you already vote on another proposal?
-            || blocked[msg.sender] != _proposalID)
+            || blocked[msg.sender] != _proposalID) {
+
             throw;
+        }
 
         // If the new DAO doesn't exist yet, create the new DAO and store the
         // current split data
@@ -669,7 +681,7 @@ contract DAO is DAOInterface, Token, TokenSale {
     }
 
 
-    function halveMinQuorum() returns (bool _success){
+    function halveMinQuorum() returns (bool _success) {
         if (lastTimeMinQuorumMet < (now - 52 weeks)) {
             lastTimeMinQuorumMet = now;
             minQuorumDivisor *= 2;
@@ -692,8 +704,9 @@ contract DAO is DAOInterface, Token, TokenSale {
     }
 
 
-    function isBlocked(address _account) returns (bool){
-        if (blocked[_account] == 0) return false;
+    function isBlocked(address _account) returns (bool) {
+        if (blocked[_account] == 0)
+            return false;
         Proposal p = proposals[blocked[_account]];
         if (!p.open) {
             blocked[_account] = 0;

--- a/DAO.sol
+++ b/DAO.sol
@@ -590,7 +590,6 @@ contract DAO is DAOInterface, Token, TokenSale {
 
 
     function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {
-    {
         if (isFunded
             && now > closingTime
             && !isBlocked(_from)

--- a/DAO.sol
+++ b/DAO.sol
@@ -16,8 +16,8 @@ along with the DAO.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-/* 
-Generic contract for a Decentralized Autonomous Organisation (DAO) to manage 
+/*
+Generic contract for a Decentralized Autonomous Organisation (DAO) to manage
 a trust
 */
 
@@ -28,12 +28,12 @@ contract DAOInterface {
 
     // Proposals to spend the DAO's ether or to choose a new service provider
     Proposal[] public proposals;
-    // The quorum needed for each proposal is partially calculated by 
+    // The quorum needed for each proposal is partially calculated by
     // totalSupply / minQuorumDivisor
     uint minQuorumDivisor;
     // The unix time of the last time quorum was reached on a proposal
     uint lastTimeMinQuorumMet;
-    // The total amount of wei received as reward that has not been sent to 
+    // The total amount of wei received as reward that has not been sent to
     // the rewardAccount
     uint public rewards;
     // Address of the service provider
@@ -41,20 +41,20 @@ contract DAOInterface {
     // The whitelist: List of addresses the DAO is allowed to send money to
     address[] public allowedRecipients;
 
-    // Tracks the addresses that own Reward Tokens. Those addresses can only be 
-    // DAOs that have split from the original DAO. Conceptually, Reward Tokens 
-    // represent the proportion of the rewards that the DAO has the right to 
+    // Tracks the addresses that own Reward Tokens. Those addresses can only be
+    // DAOs that have split from the original DAO. Conceptually, Reward Tokens
+    // represent the proportion of the rewards that the DAO has the right to
     // receive. These Reward Tokens are generated when the DAO spends ether.
     mapping (address => uint) public rewardToken;
     // Total supply of rewardToken
     uint public totalRewardToken;
 
     // The account used to manage the rewards which are to be distributed to the
-    // DAO Token Holders of any DAO that holds Reward Tokens 
+    // DAO Token Holders of any DAO that holds Reward Tokens
     ManagedAccount public rewardAccount;
     // Amount of rewards (in wei) already paid out to a certain address
     mapping (address => uint) public paidOut;
-    // Map of addresses blocked during a vote (not allowed to transfer DAO  
+    // Map of addresses blocked during a vote (not allowed to transfer DAO
     // tokens). The address points to the proposal ID.
     mapping (address => uint) public blocked;
 
@@ -62,16 +62,16 @@ contract DAOInterface {
     // requesting a new service provider (no deposit is required for splits)
     uint public proposalDeposit;
 
-    // Contract that is able to create a new DAO (with the same code as 
+    // Contract that is able to create a new DAO (with the same code as
     // this one), used for splits
     DAO_Creator public daoCreator;
 
-    // A proposal with `newServiceProvider == false` represents a transaction 
+    // A proposal with `newServiceProvider == false` represents a transaction
     // to be issued by this DAO
     // A proposal with `newServiceProvider == true` represents a DAO split
     struct Proposal {
         // The address where the `amount` will go to if the proposal is accepted
-        // or if `newServiceProvider` is true, the proposed service provider of 
+        // or if `newServiceProvider` is true, the proposed service provider of
         //the new DAO).
         address recipient;
         // The amount to transfer to `recipient` if the proposal is accepted.
@@ -82,12 +82,12 @@ contract DAOInterface {
         uint votingDeadline;
         // True if the proposal's votes have yet to be counted, otherwise False
         bool open;
-        // True if quorum has been reached, the votes have been counted, and 
+        // True if quorum has been reached, the votes have been counted, and
         // the majority said yes
         bool proposalPassed;
         // A hash to check validity of a proposal
         bytes32 proposalHash;
-        // Deposit in wei the creator added when submitting their proposal. It 
+        // Deposit in wei the creator added when submitting their proposal. It
         // is taken from the msg.value of a newProposal call.
         uint proposalDeposit;
         // True if this proposal is to assign a new service provider
@@ -120,8 +120,8 @@ contract DAOInterface {
     // Used to restrict acces to certain functions to only DAO Token Holders
     modifier onlyTokenholders {}
 
-    /// @dev Constructor setting the default service provider and the address 
-    /// for the contract able to create another DAO as well as the parameters 
+    /// @dev Constructor setting the default service provider and the address
+    /// for the contract able to create another DAO as well as the parameters
     /// for the DAO Token Sale
     /// @param _defaultServiceProvider The default service provider
     /// @param _daoCreator The contract able to (re)create this DAO
@@ -131,51 +131,51 @@ contract DAOInterface {
     /// non-zero address means that the DAO Token Sale is only for the address
     // This is the constructor: it can not be overloaded so it is commented out
     //  function DAO(
-        //  address _defaultServiceProvider, 
-        //  DAO_Creator _daoCreator, 
-        //  uint _minValue, 
-        //  uint _closingTime, 
+        //  address _defaultServiceProvider,
+        //  DAO_Creator _daoCreator,
+        //  uint _minValue,
+        //  uint _closingTime,
         //  address _privateSale
     //  )
 
-    /// @notice Buy Token with `msg.sender` as the beneficiary 
+    /// @notice Buy Token with `msg.sender` as the beneficiary
     function () returns (bool success);
 
-    /// @dev Function used by the products of the DAO (e.g. Slocks) to send 
+    /// @dev Function used by the products of the DAO (e.g. Slocks) to send
     /// rewards to the DAO
     /// @return Whether the call to this function was successful or not
     function payDAO() returns(bool);
 
-    /// @dev This function is used by the service provider to send money back 
+    /// @dev This function is used by the service provider to send money back
     /// to the DAO, it can also be used to receive payments that should not be
     /// counted as rewards (donations, grants, etc.)
     /// @return Whether the DAO received the ether successfully
     function receiveEther() returns(bool);
 
     /// @notice `msg.sender` creates a proposal to send `_amount` Wei to
-    ///  `_recipient` with the transaction data `_transactionData`. If 
-    /// `_newServiceProvider` is true, then this is a proposal that splits the 
+    ///  `_recipient` with the transaction data `_transactionData`. If
+    /// `_newServiceProvider` is true, then this is a proposal that splits the
     /// DAO and sets `_recipient` as the new DAO's new service provider.
     /// @param _recipient Address of the recipient of the proposed transaction
     /// @param _amount Amount of wei to be sent with the proposed transaction
     /// @param _description String describing the proposal
     /// @param _transactionData Data of the proposed transaction
-    /// @param _debatingPeriod Time used for debating a proposal, at least 2 
+    /// @param _debatingPeriod Time used for debating a proposal, at least 2
     /// weeks for a regular proposal, 10 days for new service provider proposal
-    /// @param _newServiceProvider Bool defining whether this proposal is about 
+    /// @param _newServiceProvider Bool defining whether this proposal is about
     /// a new service provider or not
     /// @return The proposal ID. Needed for voting on the proposal
     function newProposal(
-        address _recipient, 
-        uint _amount, 
-        string _description, 
-        bytes _transactionData, 
-        uint _debatingPeriod, 
+        address _recipient,
+        uint _amount,
+        string _description,
+        bytes _transactionData,
+        uint _debatingPeriod,
         bool _newServiceProvider
     ) onlyTokenholders returns (uint _proposalID);
 
-    /// @notice Check that the proposal with the ID `_proposalID` matches the 
-    /// transaction which sends `_amount` with data `_transactionData` 
+    /// @notice Check that the proposal with the ID `_proposalID` matches the
+    /// transaction which sends `_amount` with data `_transactionData`
     /// to `_recipient`
     /// @param _proposalID The proposal ID
     /// @param _recipient The recipient of the proposed transaction
@@ -183,9 +183,9 @@ contract DAOInterface {
     /// @param _transactionData The data of the proposed transaction
     /// @return Whether the proposal ID matches the transaction data or not
     function checkProposalCode(
-        uint _proposalID, 
-        address _recipient, 
-        uint _amount, 
+        uint _proposalID,
+        address _recipient,
+        uint _amount,
         bytes _transactionData
     ) constant returns (bool _codeChecksOut);
 
@@ -198,8 +198,8 @@ contract DAOInterface {
         bool _supportsProposal
     ) onlyTokenholders returns (uint _voteID);
 
-    /// @notice Checks whether proposal `_proposalID` with transaction data 
-    /// `_transactionData` has been voted for or rejected, and executes the 
+    /// @notice Checks whether proposal `_proposalID` with transaction data
+    /// `_transactionData` has been voted for or rejected, and executes the
     /// transaction in the case it has been voted for.
     /// @param _proposalID The proposal ID
     /// @param _transactionData The data of the proposed transaction
@@ -209,31 +209,31 @@ contract DAOInterface {
         bytes _transactionData
     ) returns (bool _success);
 
-    /// @notice ATTENTION! I confirm to move my remaining funds to a new DAO 
-    /// with `_newServiceProvider` as the new service provider, as has been 
-    /// proposed in proposal `_proposalID`. This will burn my tokens. This can 
-    /// not be undone and will split the DAO into two DAO's, with two 
+    /// @notice ATTENTION! I confirm to move my remaining funds to a new DAO
+    /// with `_newServiceProvider` as the new service provider, as has been
+    /// proposed in proposal `_proposalID`. This will burn my tokens. This can
+    /// not be undone and will split the DAO into two DAO's, with two
     /// different underlying tokens.
     /// @param _proposalID The proposal ID
     /// @param _newServiceProvider The new service provider of the new DAO
-    /// @dev This function, when called for the first time for this proposal, 
-    /// will create a new DAO and send the sender's portion of the remaining 
+    /// @dev This function, when called for the first time for this proposal,
+    /// will create a new DAO and send the sender's portion of the remaining
     /// ether and Reward Tokens to the new DAO. It will also burn the DAO Tokens
     /// of the sender. (TODO: document rewardTokens - done??)
     function splitDAO(
-        uint _proposalID, 
+        uint _proposalID,
         address _newServiceProvider
     ) returns (bool _success);
 
-    /// @notice Add a new possible recipient `_recipient` to the whitelist so 
+    /// @notice Add a new possible recipient `_recipient` to the whitelist so
     /// that the DAO can send transactions to them (using proposals)
     /// @param _recipient New recipient address
     /// @dev Can only be called by the current service provider
     function addAllowedAddress(address _recipient) external returns (bool _success);
 
-    /// @notice Change the minimum deposit required to submit a proposal 
+    /// @notice Change the minimum deposit required to submit a proposal
     /// @param _proposalDeposit The new proposal deposit
-    /// @dev Can only be called by this DAO (through proposals with the 
+    /// @dev Can only be called by this DAO (through proposals with the
     /// recipient being this DAO itself)
     function changeProposalDeposit(uint _proposalDeposit) external;
 
@@ -246,36 +246,36 @@ contract DAOInterface {
     /// @return Whether the call was successful
     function withdrawRewardFor(address _account) returns(bool _success);
 
-    /// @notice Send `_amount` tokens to `_to` from `msg.sender`. Prior to this 
+    /// @notice Send `_amount` tokens to `_to` from `msg.sender`. Prior to this
     /// getMyReward() is called.
     /// @param _to The address of the recipient
     /// @param _amount The amount of tokens to be transfered
     /// @return Whether the transfer was successful or not
     function transferWithoutReward(address _to, uint256 _amount) returns (bool success);
 
-    /// @notice Send `_amount` tokens to `_to` from `_from` on the condition it 
+    /// @notice Send `_amount` tokens to `_to` from `_from` on the condition it
     /// is approved by `_from`. Prior to this getMyReward() is called.
     /// @param _from The address of the sender
     /// @param _to The address of the recipient
     /// @param _amount The amount of tokens to be transfered
     /// @return Whether the transfer was successful or not
     function transferFromWithoutReward(
-        address _from, 
-        address _to, 
+        address _from,
+        address _to,
         uint256 _amount
     ) returns (bool success);
 
-    /// @notice Doubles the 'minQuorumDivisor' in the case quorum has not been 
+    /// @notice Doubles the 'minQuorumDivisor' in the case quorum has not been
     /// achieved in 52 weeks
     /// @return Whether the change was successful or not
     function halveMinQuorum() returns (bool _success);
 
 
     event ProposalAdded(
-        uint indexed proposalID, 
-        address recipient, 
-        uint amount, 
-        bool newServiceProvider, 
+        uint indexed proposalID,
+        address recipient,
+        uint amount,
+        bool newServiceProvider,
         string description
     );
     event Voted(uint indexed proposalID, bool position, address indexed voter);
@@ -294,10 +294,10 @@ contract DAO is DAOInterface, Token, TokenSale {
     }
 
     function DAO(
-        address _defaultServiceProvider, 
-        DAO_Creator _daoCreator, 
-        uint _minValue, 
-        uint _closingTime, 
+        address _defaultServiceProvider,
+        DAO_Creator _daoCreator,
+        uint _minValue,
+        uint _closingTime,
         address _privateSale
     ) TokenSale(_minValue, _closingTime, _privateSale) {
 
@@ -330,33 +330,33 @@ contract DAO is DAOInterface, Token, TokenSale {
 
 
     function newProposal(
-        address _recipient, 
-        uint _amount, 
-        string _description, 
-        bytes _transactionData, 
-        uint _debatingPeriod, 
+        address _recipient,
+        uint _amount,
+        string _description,
+        bytes _transactionData,
+        uint _debatingPeriod,
         bool _newServiceProvider
     ) onlyTokenholders returns (uint _proposalID) {
 
         // Sanity check
         if (_newServiceProvider && (
-            _amount != 0 
-            || _transactionData.length != 0 
-            || _recipient == serviceProvider 
-            || msg.value > 0 
+            _amount != 0
+            || _transactionData.length != 0
+            || _recipient == serviceProvider
+            || msg.value > 0
             || _debatingPeriod < 1 weeks)) {
             throw;
         } else if(
-            !_newServiceProvider 
+            !_newServiceProvider
             && (!isRecipientAllowed(_recipient) || (_debatingPeriod < 2 weeks))
         ) {
             throw;
         }
 
-        if (!isFunded 
-            || now < closingTime 
+        if (!isFunded
+            || now < closingTime
             || (msg.value < proposalDeposit && !_newServiceProvider)
-        ) 
+        )
             throw;
 
         if (_recipient == address(rewardAccount) && _amount > rewards)
@@ -380,19 +380,19 @@ contract DAO is DAOInterface, Token, TokenSale {
         p.creator = msg.sender;
         p.proposalDeposit = msg.value;
         ProposalAdded(
-            _proposalID, 
-            _recipient, 
-            _amount, 
-            _newServiceProvider, 
+            _proposalID,
+            _recipient,
+            _amount,
+            _newServiceProvider,
             _description
         );
     }
 
 
     function checkProposalCode(
-        uint _proposalID, 
-        address _recipient, 
-        uint _amount, 
+        uint _proposalID,
+        address _recipient,
+        uint _amount,
         bytes _transactionData
     ) noEther constant returns (bool _codeChecksOut) {
         Proposal p = proposals[_proposalID];
@@ -406,8 +406,8 @@ contract DAO is DAOInterface, Token, TokenSale {
     ) onlyTokenholders noEther returns (uint _voteID) {
 
         Proposal p = proposals[_proposalID];
-        if (p.votedYes[msg.sender] 
-            || p.votedNo[msg.sender] 
+        if (p.votedYes[msg.sender]
+            || p.votedNo[msg.sender]
             || now >= p.votingDeadline)
             throw;
 
@@ -440,9 +440,9 @@ contract DAO is DAOInterface, Token, TokenSale {
         // Check if the proposal can be executed
         if (now < p.votingDeadline  // has the voting deadline arrived?
             // Have the votes been counted?
-            || !p.open       
+            || !p.open
             // Does the transaction code match the proposal?
-            || p.proposalHash != sha3(p.recipient, p.amount, _transactionData)) 
+            || p.proposalHash != sha3(p.recipient, p.amount, _transactionData))
             throw;
 
         if (p.newServiceProvider) {
@@ -455,14 +455,14 @@ contract DAO is DAOInterface, Token, TokenSale {
         // Execute result
         if (quorum >= minQuorum(p.amount) && p.yea > p.nay) {
             if (!p.creator.send(p.proposalDeposit)) throw;
-            // Without this throw, the creator of the proposal can repeat this, 
+            // Without this throw, the creator of the proposal can repeat this,
             // and get so much ether
             if (!p.recipient.call.value(p.amount)(_transactionData)) throw;
             p.proposalPassed = true;
             _success = true;
             lastTimeMinQuorumMet = now;
             if (p.recipient == address(rewardAccount)) {
-                // This happens when multiple similar proposals are created and 
+                // This happens when multiple similar proposals are created and
                 // both are passed at the same time.
                 if (rewards < p.amount) throw;
                 rewards -= p.amount;
@@ -491,50 +491,50 @@ contract DAO is DAOInterface, Token, TokenSale {
         Proposal p = proposals[_proposalID];
 
         // Sanity check
-        
+
         if (now < p.votingDeadline  // has the voting deadline arrived?
             //The request for a split expires 41 days after the voting deadline
-            || now > p.votingDeadline + 41 days 
+            || now > p.votingDeadline + 41 days
             // Does the new service provider address match?
-            || p.recipient != _newServiceProvider 
+            || p.recipient != _newServiceProvider
             // Is it a new service provider proposal?
-            || !p.newServiceProvider 
+            || !p.newServiceProvider
             // Have you voted for this split?
-            || !p.votedYes[msg.sender] 
+            || !p.votedYes[msg.sender]
             // Did you already vote on another proposal?
-            || blocked[msg.sender] != _proposalID) 
+            || blocked[msg.sender] != _proposalID)
             throw;
 
-        // If the new DAO doesn't exist yet, create the new DAO and store the 
+        // If the new DAO doesn't exist yet, create the new DAO and store the
         // current split data
         if (address(p.splitData[0].newDAO) == 0) {
             p.splitData[0].newDAO = createNewDAO(_newServiceProvider);
             // Call depth limit reached, etc.
             if (address(p.splitData[0].newDAO) == 0)
-                throw; 
+                throw;
             // p.proposalDeposit should be zero here
             if (this.balance < p.proposalDeposit)
-                throw; 
+                throw;
             p.splitData[0].splitBalance = this.balance - p.proposalDeposit;
             p.splitData[0].rewardToken = rewardToken[address(this)];
             p.splitData[0].totalSupply = totalSupply;
         }
 
-        // Move funds and assign new Tokens 
-        uint fundsToBeMoved = 
+        // Move funds and assign new Tokens
+        uint fundsToBeMoved =
             (balances[msg.sender] * p.splitData[0].splitBalance) /
             p.splitData[0].totalSupply;
         if (p.splitData[0].newDAO.buyTokenProxy.value(fundsToBeMoved)(msg.sender) == false)
             throw;
-       
-       
+
+
         // Assign reward rights to new DAO
-        uint rewardTokenToBeMoved = 
+        uint rewardTokenToBeMoved =
             (balances[msg.sender] * p.splitData[0].rewardToken) /
             p.splitData[0].totalSupply;
         rewardToken[address(p.splitData[0].newDAO)] += rewardTokenToBeMoved;
         if (rewardToken[address(this)] < rewardTokenToBeMoved)
-            throw;  
+            throw;
         rewardToken[address(this)] -= rewardTokenToBeMoved;
 
         // Burn DAO Tokens
@@ -555,10 +555,10 @@ contract DAO is DAOInterface, Token, TokenSale {
 
     function withdrawRewardFor(address _account) noEther returns (bool _success) {
         // The account's portion of Reward Tokens of this DAO
-        uint portionOfTheReward = 
+        uint portionOfTheReward =
             (balanceOf(_account) * rewardToken[address(this)]) /
             totalSupply + rewardToken[_account];
-        uint reward = 
+        uint reward =
             (portionOfTheReward * rewardAccount.accumulatedInput()) /
             totalRewardToken - paidOut[_account];
         if (!rewardAccount.payOut(_account, reward))
@@ -569,10 +569,10 @@ contract DAO is DAOInterface, Token, TokenSale {
 
 
     function transfer(address _to, uint256 _value) returns (bool success) {
-        if (isFunded 
-            && now > closingTime 
-            && !isBlocked(msg.sender) 
-            && transferPaidOut(msg.sender, _to, _value) 
+        if (isFunded
+            && now > closingTime
+            && !isBlocked(msg.sender)
+            && transferPaidOut(msg.sender, _to, _value)
             && super.transfer(_to, _value)) {
 
             return true;
@@ -591,10 +591,10 @@ contract DAO is DAOInterface, Token, TokenSale {
 
     function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {
     {
-        if (isFunded 
-            && now > closingTime 
-            && !isBlocked(_from) 
-            && transferPaidOut(_from, _to, _value) 
+        if (isFunded
+            && now > closingTime
+            && !isBlocked(_from)
+            && transferPaidOut(_from, _to, _value)
             && super.transferFrom(_from, _to, _value)) {
 
             return true;
@@ -605,8 +605,8 @@ contract DAO is DAOInterface, Token, TokenSale {
 
 
     function transferFromWithoutReward(
-        address _from, 
-        address _to, 
+        address _from,
+        address _to,
         uint256 _value
     ) returns (bool success) {
 
@@ -647,8 +647,8 @@ contract DAO is DAOInterface, Token, TokenSale {
 
 
     function isRecipientAllowed(address _recipient) internal returns (bool _isAllowed) {
-        if (_recipient == serviceProvider 
-            || _recipient == address(rewardAccount) 
+        if (_recipient == serviceProvider
+            || _recipient == address(rewardAccount)
             || _recipient == address(this)
             || (_recipient == address(extraBalance)
                 // only allowed when at least the amount held in the
@@ -666,7 +666,7 @@ contract DAO is DAOInterface, Token, TokenSale {
 
     function minQuorum(uint _value) internal returns (uint _minQuorum) {
         // minimum of 20% and maximum of 53.33%
-        return totalSupply / minQuorumDivisor + _value / 3;    
+        return totalSupply / minQuorumDivisor + _value / 3;
     }
 
 
@@ -707,16 +707,16 @@ contract DAO is DAOInterface, Token, TokenSale {
 
 contract DAO_Creator {
     function createDAO(
-        address _defaultServiceProvider, 
-        uint _minValue, 
+        address _defaultServiceProvider,
+        uint _minValue,
         uint _closingTime
     ) returns (DAO _newDAO) {
 
         return new DAO(
-            _defaultServiceProvider, 
-            DAO_Creator(this), 
-            _minValue, 
-            _closingTime, 
+            _defaultServiceProvider,
+            DAO_Creator(this),
+            _minValue,
+            _closingTime,
             msg.sender
         );
     }

--- a/DAOTokenSaleProxyTransferer.sol
+++ b/DAOTokenSaleProxyTransferer.sol
@@ -15,10 +15,10 @@ You should have received a copy of the GNU lesser General Public License
 along with the DAO.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* 
+/*
 By default, token purchases can be executed on behalf of another address using the TokenSale.sol buyTokenProxy() function
 This contract is used as a fall back in case an exchange doesn't implement the "add data to a transaction" feature in a timely manner, preventing it from calling buyTokenProxy().
-Calling this contract automatically triggers a call to buyTokenProxy() using the correct parameters for a given participant in the token sale.  
+Calling this contract automatically triggers a call to buyTokenProxy() using the correct parameters for a given participant in the token sale.
 A unique instance of such a contract would have to be deployed per participant, usually using a middleware layer on a webserver, for example.
 */
 
@@ -28,25 +28,29 @@ contract DAOTokenSaleProxyTransferer {
     address public owner;
     address public dao;
 
-    //constructor 
+    //constructor
     function DAOTokenSaleProxyTransferer(address _owner, address _dao) {
         owner = _owner;
-        dao   = _dao;
-        
+        dao = _dao;
+
         // just in case somebody already added values to this address, we will forward it right now.
         sendValues();
     }
-    
-    // default-function called when values are send.    
+
+    // default-function called when values are send.
     function () {
        sendValues();
     }
-    
+
     function sendValues() {
-        if (this.balance == 0) return;
-        
+        if (this.balance == 0)
+            return;
+
         TokenSaleInterface funding = TokenSaleInterface(dao);
-        if (now > funding.closingTime() || !funding.buyTokenProxy.value(this.balance)(owner))
+        if (now > funding.closingTime() ||
+            !funding.buyTokenProxy.value(this.balance)(owner)) {
+
            owner.send(this.balance);
+        }
     }
 }

--- a/ManagedAccount.sol
+++ b/ManagedAccount.sol
@@ -30,21 +30,22 @@ contract ManagedAccountInterface {
 
 
 contract ManagedAccount is ManagedAccountInterface{
-    function ManagedAccount(address _owner){
+    function ManagedAccount(address _owner) {
         owner = _owner;
     }
 
-    function(){
+    function() {
         accumulatedInput += msg.value;
     }
 
-    function payOut(address _recipient, uint _amount) returns (bool){
-        if (msg.sender != owner || msg.value > 0) throw;
-        if (_recipient.call.value(_amount)()){
+    function payOut(address _recipient, uint _amount) returns (bool) {
+        if (msg.sender != owner || msg.value > 0)
+            throw;
+        if (_recipient.call.value(_amount)()) {
             PayOut(_recipient, _amount);
             return true;
-        }
-        else
+        } else {
             return false;
+        }
     }
 }

--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -19,8 +19,8 @@ along with the DAO.  If not, see <http://www.gnu.org/licenses/>.
 
 import "./DAO.sol";
 
-contract SampleOffer
-{
+contract SampleOffer {
+
     uint totalCosts;
     uint oneTimeCosts;
     uint dailyCosts;
@@ -40,19 +40,29 @@ contract SampleOffer
 
     modifier callingRestriction {
         if (promiseValid) {
-            if (msg.sender != address(client)) throw;
+            if (msg.sender != address(client))
+                throw;
+        } else if (msg.sender != serviceProvider) {
+                throw;
         }
-        else
-            if (msg.sender != serviceProvider) throw;
         _
     }
 
     modifier onlyClient {
-        if (msg.sender != address(client)) throw;
+        if (msg.sender != address(client))
+            throw;
         _
     }
 
-    function SampleOffer(address _serviceProvider, bytes32 _hashOfTheContract, uint _totalCosts, uint _oneTimeCosts, uint _minDailyCosts, uint _rewardDivisor, uint _deploymentReward) {
+    function SampleOffer(
+        address _serviceProvider,
+        bytes32 _hashOfTheContract,
+        uint _totalCosts,
+        uint _oneTimeCosts,
+        uint _minDailyCosts,
+        uint _rewardDivisor,
+        uint _deploymentReward
+    ) {
         serviceProvider = _serviceProvider;
         hashOfTheContract = _hashOfTheContract;
         totalCosts = _totalCosts;
@@ -64,8 +74,10 @@ contract SampleOffer
     }
 
     function sign() {
-        if (msg.value < totalCosts && dateOfSignature != 0) throw;
-        if (!serviceProvider.send(oneTimeCosts)) throw;
+        if (msg.value < totalCosts && dateOfSignature != 0)
+            throw;
+        if (!serviceProvider.send(oneTimeCosts))
+            throw;
         client = DAO(msg.sender);
         dateOfSignature = now;
         promiseValid = true;
@@ -76,25 +88,29 @@ contract SampleOffer
         if (dailyCosts < minDailyCosts)
             promiseValid = false;
     }
+
     function returnRemainingMoney() onlyClient {
         if (client.receiveEther.value(this.balance)())
-            promiseValid = false;        
+            promiseValid = false;
     }
 
     function getDailyPayment() {
-        if (msg.sender != serviceProvider) throw;
+        if (msg.sender != serviceProvider)
+            throw;
         uint amount = (now - dateOfSignature) / (1 days) * dailyCosts - paidOut;
         if (serviceProvider.send(amount))
             paidOut += amount;
     }
 
     function setRewardDivisor(uint _rewardDivisor) callingRestriction {
-        if (_rewardDivisor < 50 && msg.sender != address(client)) throw; // 2% is the default max reward
+        if (_rewardDivisor < 50 && msg.sender != address(client))
+            throw; // 2% is the default max reward
         rewardDivisor = _rewardDivisor;
     }
 
     function setDeploymentFee(uint _deploymentReward) callingRestriction {
-        if (deploymentReward > 100 ether && msg.sender != address(client)) throw; // TODO, set a max defined by service provider, or ideally oracle (set in euro)
+        if (deploymentReward > 100 ether && msg.sender != address(client))
+            throw; // TODO, set a max defined by service provider, or ideally oracle (set in euro)
         deploymentReward = _deploymentReward;
     }
 
@@ -103,24 +119,34 @@ contract SampleOffer
         if (msg.value < deploymentReward)
             throw;
         if (promiseValid) {
-            if (client.payDAO.value(msg.value)()) return true;
-            else throw;
-        }
-        else {
-            if (serviceProvider.send(msg.value)) return true;
-            else throw;
+            if (client.payDAO.value(msg.value)()) {
+                return true;
+            } else {
+                throw;
+            }
+        } else {
+            if (serviceProvider.send(msg.value)) {
+                return true;
+            } else {
+                throw;
+            }
         }
     }
 
     // pay reward
     function payReward() returns(bool) {
         if (promiseValid) {
-            if (client.payDAO.value(msg.value)()) return true;
-            else throw;
-        }
-        else {
-            if (serviceProvider.send(msg.value)) return true;
-            else throw;
+            if (client.payDAO.value(msg.value)()) {
+                return true;
+            } else {
+                throw;
+            }
+        } else {
+            if (serviceProvider.send(msg.value)) {
+                return true;
+            } else {
+                throw;
+            }
         }
     }
 }

--- a/Token.sol
+++ b/Token.sol
@@ -16,14 +16,14 @@ along with the DAO.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 /*
-Basic, standardized Token contract with no "premine."  Defines the functions to 
-check token balances, send tokens, send tokens on behalf of a 3rd party and the 
-corresponding approval process. Tokens need to be created by a derived 
+Basic, standardized Token contract with no "premine."  Defines the functions to
+check token balances, send tokens, send tokens on behalf of a 3rd party and the
+corresponding approval process. Tokens need to be created by a derived
 contract (e.g. TokenSale.sol).
 
-Thank you ConsenSys, this contract originated from: 
+Thank you ConsenSys, this contract originated from:
 https://github.com/ConsenSys/Tokens/blob/master/Token_Contracts/contracts/Standard_Token.sol
-Which is itself based on the Ethereum standardized contract APIs: 
+Which is itself based on the Ethereum standardized contract APIs:
 https://github.com/ethereum/wiki/wiki/Standardized_Contract_APIs
 */
 
@@ -46,16 +46,15 @@ contract TokenInterface {
     /// @return Whether the transfer was successful or not
     function transfer(address _to, uint256 _amount) returns (bool success);
 
-    /// @notice Send `_amount` tokens to `_to` from `_from` on the condition it 
+    /// @notice Send `_amount` tokens to `_to` from `_from` on the condition it
     /// is approved by `_from`
     /// @param _from The address of the sender
     /// @param _to The address of the recipient
     /// @param _amount The amount of tokens to be transferred
     /// @return Whether the transfer was successful or not
-    function transferFrom(address _from, address _to, uint256 _amount) 
-        returns (bool success);
+    function transferFrom(address _from, address _to, uint256 _amount) returns (bool success);
 
-    /// @notice `msg.sender` approves `_spender` to spend `_amount` tokens on 
+    /// @notice `msg.sender` approves `_spender` to spend `_amount` tokens on
     /// its behalf
     /// @param _spender The address of the account able to transfer the tokens
     /// @param _amount The amount of tokens to be approved for transfer
@@ -64,23 +63,24 @@ contract TokenInterface {
 
     /// @param _owner The address of the account owning tokens
     /// @param _spender The address of the account able to transfer the tokens
-    /// @return Amount of remaining tokens of _owner that _spender is allowed 
+    /// @return Amount of remaining tokens of _owner that _spender is allowed
     /// to spend
-    function allowance(address _owner, address _spender) 
-        constant 
-        returns (uint256 remaining);
+    function allowance(
+        address _owner,
+        address _spender
+    ) constant returns (uint256 remaining);
 
     event Transfer(address indexed _from, address indexed _to, uint256 _amount);
     event Approval(
-        address indexed _owner, 
-        address indexed _spender, 
+        address indexed _owner,
+        address indexed _spender,
         uint256 _amount
     );
 }
 
 
 contract Token is TokenInterface {
-    // Protects users by preventing the execution of method calls that 
+    // Protects users by preventing the execution of method calls that
     // inadvertently also transferred ether
     modifier noEther() {if (msg.value > 0) throw; _}
 
@@ -88,36 +88,35 @@ contract Token is TokenInterface {
         return balances[_owner];
     }
 
-    function transfer(address _to, uint256 _amount) 
-        noEther 
-        returns (bool success) 
-    {
+    function transfer(address _to, uint256 _amount) noEther returns (bool success) {
         if (balances[msg.sender] >= _amount && _amount > 0) {
             balances[msg.sender] -= _amount;
             balances[_to] += _amount;
             Transfer(msg.sender, _to, _amount);
             return true;
-        }
-        else
+        } else {
            return false;
+        }
     }
 
-    function transferFrom(address _from, address _to, uint256 _amount) 
-        noEther 
-        returns (bool success) 
-    {
-        if (balances[_from] >= _amount 
-            && allowed[_from][msg.sender] >= _amount 
-            && _amount > 0
-        ) {
+    function transferFrom(
+        address _from,
+        address _to,
+        uint256 _amount
+    ) noEther returns (bool success) {
+
+        if (balances[_from] >= _amount
+            && allowed[_from][msg.sender] >= _amount
+            && _amount > 0) {
+
             balances[_to] += _amount;
             balances[_from] -= _amount;
             allowed[_from][msg.sender] -= _amount;
             Transfer(_from, _to, _amount);
             return true;
-        }
-        else
+        } else {
             return false;
+        }
     }
 
     function approve(address _spender, uint256 _amount) returns (bool success) {
@@ -126,10 +125,7 @@ contract Token is TokenInterface {
         return true;
     }
 
-    function allowance(address _owner, address _spender) 
-        constant 
-        returns (uint256 remaining) 
-    {
+    function allowance(address _owner, address _spender) constant returns (uint256 remaining) {
         return allowed[_owner][_spender];
     }
 }

--- a/TokenSale.sol
+++ b/TokenSale.sol
@@ -24,13 +24,13 @@ import "./Token.sol";
 import "./ManagedAccount.sol";
 
 contract TokenSaleInterface {
-    
+
     // End of token sale, in Unix time
-    uint public closingTime;   
+    uint public closingTime;
     // Minimum funding goal of the token sale, denominated in tokens
-    uint public minValue;  
+    uint public minValue;
     // True if the DAO reached its minimum funding goal, false otherwise
-    bool public isFunded;   
+    bool public isFunded;
     // For DAO splits - if privateSale is 0, then it is a public sale, otherwise
     // only the address stored in privateSale is allowed to purchase tokens
     address public privateSale;
@@ -38,8 +38,8 @@ contract TokenSaleInterface {
     ManagedAccount extraBalance;
     // tracks the amount of wei given from each contributor (used for refund)
     mapping (address => uint256) weiGiven;
-    
-    /// @dev Constructor setting the minimum funding goal and the 
+
+    /// @dev Constructor setting the minimum funding goal and the
     /// end of the Token Sale
     /// @param _minValue Token Sale minimum funding goal
     /// @param _closingTime Date (in Unix time) of the end of the Token Sale
@@ -47,10 +47,10 @@ contract TokenSaleInterface {
     //  function TokenSale(uint _minValue, uint _closingTime);
 
     /// @notice Buy Token with `_tokenHolder` as the initial owner of the Token
-    /// @param _tokenHolder The address of the Tokens's recipient 
+    /// @param _tokenHolder The address of the Tokens's recipient
     function buyTokenProxy(address _tokenHolder) returns (bool success);
 
-    /// @notice Refund `msg.sender` in the case the Token Sale didn't reach its 
+    /// @notice Refund `msg.sender` in the case the Token Sale didn't reach its
     /// minimum funding goal
     function refund();
 
@@ -72,8 +72,9 @@ contract TokenSale is TokenSaleInterface, Token {
     }
 
     function buyTokenProxy(address _tokenHolder) returns (bool success) {
-        if (now < closingTime && msg.value > 0 
-        && (privateSale == 0 || privateSale == msg.sender)) {
+        if (now < closingTime && msg.value > 0
+            && (privateSale == 0 || privateSale == msg.sender)) {
+
             uint token = (msg.value * 20) / divisor();
             extraBalance.call.value(msg.value - token)();
             balances[_tokenHolder] += token;
@@ -103,15 +104,18 @@ contract TokenSale is TokenSaleInterface, Token {
         }
     }
 
-    function divisor() returns (uint divisor){
+    function divisor() returns (uint divisor) {
         // the number of (base unit) tokens per wei is calculated
         // as `msg.value` * 20 / `divisor`
         // the funding period starts with a 1:1 ratio
-        if (closingTime - 2 weeks > now) return 20;
+        if (closingTime - 2 weeks > now) {
+            return 20;
         // followed by 10 days with a daily price increase of 5%
-        else if (closingTime - 4 days > now)
+        } else if (closingTime - 4 days > now) {
             return (20 + (now - (closingTime - 2 weeks)) / (1 days));
         // the last 4 days there is a constant price ratio of 1:1,5
-        else return 30;
+        } else {
+            return 30;
+        }
     }
 }

--- a/tests/args.py
+++ b/tests/args.py
@@ -86,7 +86,7 @@ def test_args():
     )
     p.add_argument(
         '--scenario',
-        choices=['none', 'deploy', 'fund', 'proposal', 'rewards'],
+        choices=['none', 'deploy', 'fund', 'proposal', 'rewards', 'split'],
         default='none',
         help='Test scenario to play out'
     )

--- a/tests/templates/deploy.template.js
+++ b/tests/templates/deploy.template.js
@@ -22,8 +22,7 @@ var _daoCreatorContract = creatorContract.new(
 		    {
 		        from: web3.eth.accounts[0],
 		        data: '$dao_bin',
-		        gas: 3000000,
-		        gasPrice: 500000000000
+		        gas: 4000000
 		    }, function (e, contract) {
 		        // funny thing, without this geth hangs
 		        console.log("At DAO creation callback");

--- a/tests/templates/fund.template.js
+++ b/tests/templates/fund.template.js
@@ -6,7 +6,7 @@ for (i = 0; i < eth.accounts.length; i++) {
     web3.eth.sendTransaction({
         from:eth.accounts[i],
         to: dao.address,
-        gas:100000,
+        gas:200000,
         value:web3.toWei(amounts[i], "ether")
     });
 }
@@ -27,7 +27,7 @@ setTimeout(function() {
     web3.eth.sendTransaction({
         from:eth.accounts[0],
         to: dao.address,
-        gas:100000,
+        gas:200000,
         value:web3.toWei(20, "ether")
     });
     // and confirm balance is still the same

--- a/tests/templates/rewards.template.js
+++ b/tests/templates/rewards.template.js
@@ -68,6 +68,8 @@ setTimeout(function() {
             testMap['provider_balance_after_claim'], testMap['provider_balance_before_claim']
         )))
     );
+    addToTest('DAO_balance', parseFloat(web3.fromWei(eth.getBalance('$dao_address'))));
+    addToTest('DAO_rewardToken', parseFloat(web3.fromWei(dao.rewardToken('$dao_address'))));
     testResults();
 }, $debating_period * 1000);
 console.log("Wait for end of debating period");

--- a/tests/templates/split.template.js
+++ b/tests/templates/split.template.js
@@ -1,0 +1,82 @@
+var dao = web3.eth.contract($dao_abi).at('$dao_address');
+var newServiceProvider = eth.accounts[1];
+
+// create a new proposal for sending this whole donation to the rewardAccount
+console.log("Creating proposal to change SP...");
+var tx_hash = null;
+dao.newProposal.sendTransaction(
+    newServiceProvider, // new SP
+    0,
+    'Changing SP to eth.accounts[1]',
+    '',
+    $debating_period,
+    true,
+    {
+        from: proposalCreator,
+        gas: 1000000
+    }
+    , function (e, res) {
+        if (e) {
+            console.log(e + "at newProposal()!");
+        } else {
+            tx_hash = res;
+            console.log("newProposal tx hash is: " + tx_hash);
+        }
+    }
+);
+checkWork();
+
+var votes = $votes;
+var prop_id = $prop_id;
+console.log("Voting for split proposal '" + prop_id + "' ...");
+for (i = 0; i < votes.length; i++) {
+    dao.vote.sendTransaction(
+        prop_id,
+        votes[i],
+        {
+            from: eth.accounts[i],
+            gas: 1000000
+        }
+    );
+}
+checkWork();
+addToTest('proposal_yay', parseInt(web3.fromWei(dao.proposals(prop_id)[9])));
+addToTest('proposal_nay', parseInt(web3.fromWei(dao.proposals(prop_id)[10])));
+
+setTimeout(function() {
+    miner.stop(0);
+    console.log("Executing the split proposal...");
+    // now each user who voted for the split should call splitDAO to execute the proposal
+    for (i = 0; i < votes.length; i++) {
+        if (votes[i]) {
+            dao.splitDAO.sendTransaction(
+                prop_id,
+                newServiceProvider,
+                {from:eth.accounts[i], gas:3000000}
+            );
+        }
+    }
+    checkWork();
+    console.log("After split execution");
+    addToTest('proposal_passed', dao.proposals(prop_id)[5]);
+    addToTest('proposal_newdao', dao.splitProposalNewAddress(prop_id, 0));
+
+    var newdao = web3.eth.contract($dao_abi).at(testMap['proposal_newdao']);
+    // check token balance of each user in both DAOs
+    oldDAOBalance = [];
+    newDAOBalance = [];
+    for (i = 0; i < eth.accounts.length; i++) {
+        oldDAOBalance.push(parseInt(web3.fromWei(dao.balanceOf(eth.accounts[i]))));
+        newDAOBalance.push(parseInt(web3.fromWei(newdao.balanceOf(eth.accounts[i]))));
+    }
+    addToTest('oldDAOBalance', oldDAOBalance);
+    addToTest('newDAOBalance', newDAOBalance);
+    addToTest('oldDaoRewardTokens', parseFloat(web3.fromWei(dao.rewardToken('$dao_address'))));
+    addToTest('newDaoRewardTokens', parseFloat(web3.fromWei(dao.rewardToken(testMap['proposal_newdao']))));
+
+    addToTest('newDAOTotalSupply', parseInt(web3.fromWei(newdao.totalSupply())));
+    addToTest('newDAOProposalDeposit', parseInt(web3.fromWei(newdao.proposalDeposit())));
+
+    testResults();
+}, $debating_period * 1000);
+console.log("Wait for end of debating period");

--- a/tests/templates/split.template.js
+++ b/tests/templates/split.template.js
@@ -52,7 +52,7 @@ setTimeout(function() {
             dao.splitDAO.sendTransaction(
                 prop_id,
                 newServiceProvider,
-                {from:eth.accounts[i], gas:3000000}
+                {from:eth.accounts[i], gas:4000000}
             );
         }
     }

--- a/tests/test.py
+++ b/tests/test.py
@@ -156,7 +156,6 @@ class TestContext():
             print("DAO contract not found at {}".format(dao_contract))
             sys.exit(1)
         dao_contract = edit_dao_source(
-            dao_contract,
             self.contracts_dir,
             keep_limits
         )
@@ -174,9 +173,9 @@ class TestContext():
         self.offer_abi = res["contracts"]["SampleOffer"]["abi"]
         self.offer_bin = res["contracts"]["SampleOffer"]["bin"]
 
-        if not keep_limits:
-            # also delete the temporary created file
-            rm_file(dao_contract)
+        # also delete the temporary created files
+        rm_file(os.path.join(self.contracts_dir, "DAOcopy.sol"))
+        rm_file(os.path.join(self.contracts_dir, "TokenSaleCopy.sol"))
 
     def create_js_file(self, name, substitutions, cb_before_creation=None):
         """
@@ -229,9 +228,16 @@ class TestContext():
         output = self.run_script('deploy.js')
         results = extract_test_dict('deploy', output)
 
-        self.dao_creator_addr = results['dao_creator_address']
-        self.dao_addr = results['dao_address']
-        self.offer_addr = results['offer_address']
+        try:
+            self.dao_creator_addr = results['dao_creator_address']
+            self.dao_addr = results['dao_address']
+            self.offer_addr = results['offer_address']
+        except:
+            print(
+                "ERROR: Could not find expected results in the deploy scenario"
+                ". The output was:\n{}".format(output)
+            )
+            sys.exit(1)
         print("DAO Creator address is: {}".format(self.dao_creator_addr))
         print("DAO address is: {}".format(self.dao_addr))
         print("SampleOffer address is: {}".format(self.offer_addr))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -301,8 +301,8 @@ def tokens_after_split(votes, original_balance, dao_balance, reward_tokens):
             new_dao_balance.append(orig * dao_balance / totalSupply)
             old_dao_balance.append(0)
             rewardToMove = float(orig) * reward_tokens / float(totalSupply)
-            old_reward_tokens -= rewardToMove
-            new_reward_tokens += rewardToMove
+            old_reward_tokens -= float(rewardToMove)
+            new_reward_tokens += float(rewardToMove)
         else:
             old_dao_balance.append(orig)
             new_dao_balance.append(0)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -141,8 +141,9 @@ def eval_test(name, output, expected_dict):
     if not tests_fail:
         print("Tests for '{}' PASSED!".format(name))
     else:
-        print("Tests for '{}' FAILED!".format(name))
+        print("Tests for '{}' FAILED! Script output was:\n{}".format(name, output))
         sys.exit(1)
+    return results
 
 
 def write_js(name, contents, accounts_num):
@@ -190,3 +191,111 @@ def calculate_closing_time(obj, script_name, substitutions):
     obj.closing_time = seconds_in_future(obj.args.closing_time)
     substitutions['closing_time'] = obj.closing_time
     return substitutions
+
+
+def edit_dao_source(dao_contract, contracts_dir, keep_limits):
+
+    with open(dao_contract, 'r') as f:
+        contents = f.read()
+
+    # remove all limits that would make testing impossible
+    if not keep_limits:
+        contents = contents.replace(" || _debatingPeriod < 1 weeks", "")
+        contents = contents.replace(" || (_debatingPeriod < 2 weeks)", "")
+        contents = contents.replace("|| now > p.votingDeadline + 41 days", "")
+
+    # add test query functions
+    contents = contents.replace(
+        "contract DAO is DAOInterface, Token, TokenSale {",
+        """contract DAO is DAOInterface, Token, TokenSale {
+
+        function splitProposalBalance(uint pid, uint sid) constant returns (uint _balance) {
+            Proposal p = proposals[pid];
+            if (!p.newServiceProvider) throw;
+            SplitData s = p.splitData[sid];
+            return s.splitBalance;
+        }
+
+        function splitProposalSupply(uint pid, uint sid) constant returns (uint _supply) {
+            Proposal p = proposals[pid];
+            if (!p.newServiceProvider) throw;
+            SplitData s = p.splitData[sid];
+            return s.totalSupply;
+        }
+
+        function splitProposalrewardToken(uint pid, uint sid) constant returns (uint _rewardToken) {
+            Proposal p = proposals[pid];
+            if (!p.newServiceProvider) throw;
+            SplitData s = p.splitData[sid];
+            return s.rewardToken;
+        }
+
+        function splitProposalNewAddress(uint pid, uint sid) constant returns (address _DAO) {
+            Proposal p = proposals[pid];
+            if (!p.newServiceProvider) throw;
+            SplitData s = p.splitData[sid];
+            return address(s.newDAO);
+        }
+"""
+    )
+
+    new_path = os.path.join(contracts_dir, "DAOcopy.sol")
+    with open(new_path, "w") as f:
+        f.write(contents)
+    return new_path
+
+
+def tokens_after_split(votes, original_balance, dao_balance, reward_tokens):
+    """
+    Create expected token and reward token results after the split scenario
+        Parameters
+        ----------
+        votes : array of booleans
+        The votes array of what each user voted
+
+        original_balance : array of ints
+        The original amount of tokens each user had before the split
+
+        dao_balance : int
+        The balance of ether left in the DAO before the scenario started
+
+        reward_tokens : float
+        Amount of reward tokens generated in the DAO before the scenario.
+
+        Returns
+        ----------
+        old_dao_balance : array of ints
+        The balance of tokens left in the old dao.
+
+        new_dao_balance : array of ints
+        The balance of tokens left in the new dao.
+
+        old_reward_tokens : float
+        The amount of reward tokens left in the old dao.
+
+        new_reward_tokens : float
+        The amount of reward tokens left in the new dao.
+    """
+
+    old_dao_balance = []
+    new_dao_balance = []
+    totalSupply = sum(original_balance)
+    old_reward_tokens = reward_tokens
+    new_reward_tokens = 0
+
+    for vote, orig in zip(votes, original_balance):
+        if vote:
+            new_dao_balance.append(orig * dao_balance / totalSupply)
+            old_dao_balance.append(0)
+            rewardToMove = float(orig) * reward_tokens / float(totalSupply)
+            old_reward_tokens -= rewardToMove
+            new_reward_tokens += rewardToMove
+        else:
+            old_dao_balance.append(orig)
+            new_dao_balance.append(0)
+    return (
+        old_dao_balance,
+        new_dao_balance,
+        old_reward_tokens,
+        new_reward_tokens
+    )


### PR DESCRIPTION
This depends on the [DAO Split tests](https://github.com/slockit/DAO/pull/30) PR, so please merge it first and only then merge this one.

With this PR I am making the contracts have a consistent style as discussed in the codebase channel of the slack.

From now on everyone *PLEASE* make sure you editors do not add any stray whitespace. The code was full of them.

Main changes:

- Removed extraneous whitespace
- Enforced consistent `if {} else {}` behaviour
- Forced legs of conditionals to always be on the next line
- The 80 char limit is a soft limit. If it makes things look really bad for a line and is a few chars above  the limit then obviously keep it in the same line.
- Function modifiers should never break. Keep them in the same line.
- Lots of whitespace missing around `{}` and `()` in various part of the code