### PR TITLE
Homesteadify tests and add insufficient gas at split test

### DIFF
--- a/tests/args.py
+++ b/tests/args.py
@@ -86,7 +86,15 @@ def test_args():
     )
     p.add_argument(
         '--scenario',
-        choices=['none', 'deploy', 'fund', 'proposal', 'rewards', 'split'],
+        choices=[
+            'none',
+            'deploy',
+            'fund',
+            'proposal',
+            'rewards',
+            'split',
+            'split-insufficient-gas'
+        ],
         default='none',
         help='Test scenario to play out'
     )

--- a/tests/templates/split.template.js
+++ b/tests/templates/split.template.js
@@ -52,7 +52,7 @@ setTimeout(function() {
             dao.splitDAO.sendTransaction(
                 prop_id,
                 newServiceProvider,
-                {from:eth.accounts[i], gas:4000000}
+                {from:eth.accounts[i], gas: $split_gas}
             );
         }
     }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -124,6 +124,25 @@ def compare_values(a, b):
 
 
 def eval_test(name, output, expected_dict):
+    """
+    Evaluate output of a scenario and compare with expected results
+        Parameters
+        ----------
+        name : string
+        The name of the scenario to evaluate
+
+        output : string
+        The output of the script that was executed, from which we will
+        extract the results
+
+        expected_dict : dict
+        A dictionary containing all the expected output from the test
+
+        Returns
+        ----------
+        results : dict
+        The dictionary that resulted from the parsing of the test output
+    """
     tests_fail = False
     results = extract_test_dict(name, output)
 
@@ -139,9 +158,11 @@ def eval_test(name, output, expected_dict):
             ))
 
     if not tests_fail:
-        print("Tests for '{}' PASSED!".format(name))
+        print("Tests for scenario '{}' PASSED!".format(name))
     else:
-        print("Tests for '{}' FAILED! Script output was:\n{}".format(name, output))
+        print("Tests for scenario '{}' FAILED! Script output was:\n{}".format(
+            name, output)
+        )
         sys.exit(1)
     return results
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -157,11 +157,18 @@ def create_genesis(accounts):
     genesis = {}
     genesis["nonce"] = "0xdeadbeefdeadbeef"
     genesis["timestamp"] = "0x0"
-    genesis["parentHash"] = "0x0000000000000000000000000000000000000000000000000000000000000000"
+    # Start after homesteam
+    genesis["parentHash"] = (
+        "0x584bdb5d4e74fe97f5a5222b533fe1322fd0b6ad3eb03f02c3221984e2c0b430"
+    )
     genesis["extraData"] = "0x0"
     genesis["gasLimit"] = "0x8000000"
-    genesis["difficulty"] = "0x000000001"
-    genesis["mixhash"] = "0x0000000000000000000000000000000000000000000000000000000000000000"
+    genesis["difficulty"] = (
+        "0x0000000000000000000000000000000000000000000000000000000000000001"
+    )
+    genesis["mixhash"] = (
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+    )
     alloc = {}
     for acc in accounts:
         alloc[acc] = {"balance": "133700000000000000000000000000000000"}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -180,10 +180,10 @@ def create_genesis(accounts):
     genesis["timestamp"] = "0x0"
     # Start after homesteam
     genesis["parentHash"] = (
-        "0x584bdb5d4e74fe97f5a5222b533fe1322fd0b6ad3eb03f02c3221984e2c0b430"
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
     )
     genesis["extraData"] = "0x0"
-    genesis["gasLimit"] = "0x8000000"
+    genesis["gasLimit"] = "0x47e7c4"
     genesis["difficulty"] = (
         "0x0000000000000000000000000000000000000000000000000000000000000001"
     )


### PR DESCRIPTION
- Tests genesis block will now start right after the homestead one 
- Adding test for insufficient gas at DAO split.
   
This test makes sure that if there is not enough gas given at a daoSplit() event the new DAO is not created at all.

This should work thanks to this homestead change:
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.mediawiki#specification

Before homestead the test would fail, but create an empty/invalid new
DAO address which would lead to people burning their tokens in their old
DAO and transferring them to a new invalid DAO, thus losing their money.