### PR TITLE
Refund scenario for buyTokenProxy() usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tests/out.log.geth
 tests/deploy.js
 tests/fund.js
 tests/fund_fail.js
+tests/fund_fail2.js
 tests/proposal.js
 tests/accounts.js
 tests/rewards.js

--- a/TokenSale.sol
+++ b/TokenSale.sol
@@ -79,7 +79,7 @@ contract TokenSale is TokenSaleInterface, Token {
             extraBalance.call.value(msg.value - token)();
             balances[_tokenHolder] += token;
             totalSupply += token;
-            weiGiven[msg.sender] += msg.value;
+            weiGiven[_tokenHolder] += msg.value;
             SoldToken(_tokenHolder, token);
             if (totalSupply >= minValue && !isFunded) {
                 isFunded = true;

--- a/tests/jsutils.py
+++ b/tests/jsutils.py
@@ -6,11 +6,12 @@ def js_common_intro(accounts_num):
     s = "console.log('unlocking accounts');\n"
     for i in range(0, accounts_num):
         s += "personal.unlockAccount(eth.accounts[{}], '123');\n".format(i)
-    s += """// set coinbase to something other than service provider and proposal creator
-web3.miner.setEtherbase(eth.accounts[2]);
-
+    s += """// set the basic accounts, coinbase should be random so mining rewards don't pollute results
 var serviceProvider = eth.accounts[0];
 var proposalCreator = eth.accounts[1];
+var etherBase = '0x9999999999999999999999999999999999999999';
+web3.miner.setEtherbase(etherBase);
+
 var testMap = {};
 
 function checkWork() {

--- a/tests/scenarios/fund_fail/run.py
+++ b/tests/scenarios/fund_fail/run.py
@@ -48,5 +48,5 @@ def run(framework):
     framework.execute('fund_fail', {
         "dao_funded": False,
         "total_supply": framework.total_supply,
-        "refund": framework.token_amounts[0:2]
+        "refund": framework.token_amounts
     })

--- a/tests/scenarios/fund_fail/template.js
+++ b/tests/scenarios/fund_fail/template.js
@@ -21,7 +21,7 @@ setTimeout(function() {
 
     // since funding failed let's get a refund (only first 2 users for now)
     var eth_balance_before_refund = [];
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < eth.accounts.length; i++) {
         eth_balance_before_refund.push(web3.fromWei(eth.getBalance(eth.accounts[i])));
     }
     addToTest('eth_balance_before_refund', eth_balance_before_refund);
@@ -42,13 +42,13 @@ setTimeout(function() {
     }
     checkWork();
     var eth_balance_after_refund = [];
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < eth.accounts.length; i++) {
         eth_balance_after_refund.push(web3.fromWei(eth.getBalance(eth.accounts[i])));
     }
     addToTest('eth_balance_after_refund', eth_balance_after_refund);
 
     var refund = [];
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < eth.accounts.length; i++) {
         refund.push((bigDiffRound(
             testMap['eth_balance_after_refund'][i],
             testMap['eth_balance_before_refund'][i]

--- a/tests/scenarios/fund_fail2/run.py
+++ b/tests/scenarios/fund_fail2/run.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import sys
 import random
 from datetime import datetime
 currentdir = os.path.dirname(
@@ -16,9 +17,9 @@ def run(framework):
         framework.run_scenario('deploy')
     else:
         print(
-            "WARNING: Running the failed funding scenario with a pre-deployed "
-            "DAO contract. Closing time is {} which is approximately {} "
-            "seconds from now.".format(
+            "WARNING: Running the failed funding 2 scenario with a "
+            "pre-deployed DAO contract. Closing time is {} which is "
+            "approximately {} seconds from now.".format(
                 datetime.fromtimestamp(framework.closing_time).strftime(
                     '%Y-%m-%d %H:%M:%S'
                 ),
@@ -27,25 +28,38 @@ def run(framework):
         )
 
     accounts_num = len(framework.accounts)
+    if accounts_num * 2 >= framework.min_value - 4:
+        print("Please increase the minimum funding goal for the scenario.")
+        sys.exit(1)
+
     sale_secs = framework.closing_time - ts_now()
-    framework.total_supply = random.randint(5, framework.min_value - 4)
-    framework.token_amounts = constrained_sum_sample_pos(
-        accounts_num, framework.total_supply
+    # total_supply = random.randint(accounts_num*2, framework.min_value - 4)
+    total_supply = framework.min_value - 4
+    proxy_amounts = constrained_sum_sample_pos(
+        accounts_num, total_supply / 2
     )
+    normal_amounts = constrained_sum_sample_pos(
+        accounts_num, total_supply / 2
+    )
+    framework.token_amounts = [
+        sum(x) for x in zip(proxy_amounts[::-1], normal_amounts)
+    ]
+    framework.total_supply = sum(framework.token_amounts)
     framework.create_js_file(
-        'fund_fail',
+        'fund_fail2',
         {
             "dao_abi": framework.dao_abi,
             "dao_address": framework.dao_addr,
             "wait_ms": (sale_secs-3)*1000,
-            "amounts": arr_str(framework.token_amounts)
+            "proxy_amounts": arr_str(proxy_amounts),
+            "normal_amounts": arr_str(normal_amounts)
         }
     )
     print(
         "Notice: Funding period is {} seconds so the test will wait "
         "as much".format(sale_secs)
     )
-    framework.execute('fund_fail', {
+    framework.execute('fund_fail2', {
         "dao_funded": False,
         "total_supply": framework.total_supply,
         "refund": framework.token_amounts

--- a/tests/scenarios/fund_fail2/template.js
+++ b/tests/scenarios/fund_fail2/template.js
@@ -1,13 +1,23 @@
-var amounts = $amounts;
+var proxy_amounts = $proxy_amounts;
+var normal_amounts = $normal_amounts;
 
 var dao = web3.eth.contract($dao_abi).at('$dao_address');
 console.log("Buying DAO tokens");
+for (i = 0; i < eth.accounts.length; i++) {
+    dao.buyTokenProxy.sendTransaction(
+        eth.accounts[eth.accounts.length - 1 - i],
+        {
+        from:eth.accounts[i],
+        gas:200000,
+        value:web3.toWei(proxy_amounts[i], "ether")
+    });
+}
 for (i = 0; i < eth.accounts.length; i++) {
     web3.eth.sendTransaction({
         from:eth.accounts[i],
         to: dao.address,
         gas:200000,
-        value:web3.toWei(amounts[i], "ether")
+        value:web3.toWei(normal_amounts[i], "ether")
     });
 }
 
@@ -25,12 +35,12 @@ setTimeout(function() {
         eth_balance_before_refund.push(web3.fromWei(eth.getBalance(eth.accounts[i])));
     }
     addToTest('eth_balance_before_refund', eth_balance_before_refund);
-    
+
     for (i = 0; i < eth.accounts.length; i++) {
         dao.refund.sendTransaction({
             from:eth.accounts[i],
             gas:200000
-        }); 
+        });
     }
     checkWork();
     // try to ask for a refund again and see if we get more (we shouldn't)
@@ -38,7 +48,7 @@ setTimeout(function() {
         dao.refund.sendTransaction({
             from:eth.accounts[i],
             gas:200000
-        }); 
+        });
     }
     checkWork();
     var eth_balance_after_refund = [];


### PR DESCRIPTION
- Changed the coinbase to random account so that test results don't get polluted after mining
- With coinbase out of the way, improved normal funding_fail scenario to check balance of all accounts
- [under discussion] Changed `buyTokenProxy()` to track `tokenHolder` and not `msg.sender` at the `weiGiven` map