### PR TITLE
added reference to whitepaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A generic DAO (Decentralized Autonomous Organization) written in Solidity to run
 Simple, decentralized and 100% secure.
 Feel free to reuse to create your own Decentralized organization.
 
-• **Scientific Reference:** *"Decentralized autonomous organization to manage a trust" -* [White Paper (Draft)](https://github.com/slockit/DAO/tree/master/paper)
+**Reference:** *"Decentralized autonomous organization to manage a trust" -* [White Paper (Draft)](https://download.slock.it/public/DAO/WhitePaper.pdf)
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A generic DAO (Decentralized Autonomous Organization) written in Solidity to run
 Simple, decentralized and 100% secure.
 Feel free to reuse to create your own Decentralized organization.
 
-**Reference:** *"Decentralized autonomous organization to manage a trust" -* [White Paper (Draft)](https://download.slock.it/public/DAO/WhitePaper.pdf)
+**Reference:** *"Decentralized Autonomous Organization to manage a trust" -* [White Paper (Draft)](https://download.slock.it/public/DAO/WhitePaper.pdf)
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A generic DAO (Decentralized Autonomous Organization) written in Solidity to run
 Simple, decentralized and 100% secure.
 Feel free to reuse to create your own Decentralized organization.
 
+• **Scientific Reference:** *"Decentralized autonomous organization to manage a trust" -* [White Paper (Draft)](https://github.com/slockit/DAO/tree/master/paper)
 
 ## How it works
 


### PR DESCRIPTION
This seemed like the best spot to reference the science/math behind the DOA.

It could also be between `### DAOTokenSaleProxyTransferer.sol` & `## Contact`

or after `## Contact`

but right at the beginning made the most sense.