### PR TITLE
use payDAO as fallback

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -325,7 +325,7 @@ contract DAO is DAOInterface, Token, TokenSale {
         if (now < closingTime + 40 days)
             return buyTokenProxy(msg.sender);
         else
-            return receiveEther();
+            return payDAO();
     }
 
 


### PR DESCRIPTION
 to account for rewards from mother DAO counted correctly.
Lets say somone split two time. So we have DAOs A  -B -C (B originates from A, C originates from B). Then C does not receive his reards from A, since they are recieved using the fallback function, and `rewards` is not increased.