### PR TITLE
Single split scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tests/proposal.js
 tests/accounts.js
 tests/rewards.js
 tests/split.js
+tests/singlesplit.js
 
 # python metadata in tests
 *.pyc

--- a/tests/scenarios/deploy/run.py
+++ b/tests/scenarios/deploy/run.py
@@ -9,41 +9,41 @@ def calculate_closing_time(obj, script_name, substitutions):
     return substitutions
 
 
-def run(framework):
+def run(ctx):
     print("Running the Deploy Test Scenario")
-    framework.create_js_file(substitutions={
-            "dao_abi": framework.dao_abi,
-            "dao_bin": framework.dao_bin,
-            "creator_abi": framework.creator_abi,
-            "creator_bin": framework.creator_bin,
-            "offer_abi": framework.offer_abi,
-            "offer_bin": framework.offer_bin,
-            "offer_onetime": framework.args.deploy_onetime_costs,
-            "offer_total": framework.args.deploy_total_costs,
-            "min_value": framework.args.deploy_min_value,
+    ctx.create_js_file(substitutions={
+            "dao_abi": ctx.dao_abi,
+            "dao_bin": ctx.dao_bin,
+            "creator_abi": ctx.creator_abi,
+            "creator_bin": ctx.creator_bin,
+            "offer_abi": ctx.offer_abi,
+            "offer_bin": ctx.offer_bin,
+            "offer_onetime": ctx.args.deploy_onetime_costs,
+            "offer_total": ctx.args.deploy_total_costs,
+            "min_value": ctx.args.deploy_min_value,
         },
         cb_before_creation=calculate_closing_time
     )
-    output = framework.run_script('deploy.js')
+    output = ctx.run_script('deploy.js')
     results = extract_test_dict('deploy', output)
 
     try:
-        framework.dao_creator_addr = results['dao_creator_address']
-        framework.dao_addr = results['dao_address']
-        framework.offer_addr = results['offer_address']
+        ctx.dao_creator_addr = results['dao_creator_address']
+        ctx.dao_addr = results['dao_address']
+        ctx.offer_addr = results['offer_address']
     except:
         print(
             "ERROR: Could not find expected results in the deploy scenario"
             ". The output was:\n{}".format(output)
         )
         sys.exit(1)
-    print("DAO Creator address is: {}".format(framework.dao_creator_addr))
-    print("DAO address is: {}".format(framework.dao_addr))
-    print("SampleOffer address is: {}".format(framework.offer_addr))
-    with open(framework.save_file, "w") as f:
+    print("DAO Creator address is: {}".format(ctx.dao_creator_addr))
+    print("DAO address is: {}".format(ctx.dao_addr))
+    print("SampleOffer address is: {}".format(ctx.offer_addr))
+    with open(ctx.save_file, "w") as f:
         f.write(json.dumps({
-            "dao_creator_addr": framework.dao_creator_addr,
-            "dao_addr": framework.dao_addr,
-            "offer_addr": framework.offer_addr,
-            "closing_time": framework.closing_time
+            "dao_creator_addr": ctx.dao_creator_addr,
+            "dao_addr": ctx.dao_addr,
+            "offer_addr": ctx.offer_addr,
+            "closing_time": ctx.closing_time
         }))

--- a/tests/scenarios/deposit/run.py
+++ b/tests/scenarios/deposit/run.py
@@ -7,27 +7,27 @@ def calculate_bytecode(new_deposit):
     return "{0}{1:0{2}x}".format('0xe33734fd', new_deposit, 64)
 
 
-def run(framework):
-    if not framework.token_amounts:
+def run(ctx):
+    if not ctx.token_amounts:
         # run the funding scenario first
-        framework.run_scenario('fund')
+        ctx.run_scenario('fund')
 
-    bytecode = calculate_bytecode(framework.args.deposit_new_value)
-    framework.create_js_file(substitutions={
-            "dao_abi": framework.dao_abi,
-            "dao_address": framework.dao_addr,
-            "proposal_deposit": framework.args.proposal_deposit,
+    bytecode = calculate_bytecode(ctx.args.deposit_new_value)
+    ctx.create_js_file(substitutions={
+            "dao_abi": ctx.dao_abi,
+            "dao_address": ctx.dao_addr,
+            "proposal_deposit": ctx.args.proposal_deposit,
             "transaction_bytecode": bytecode,
-            "debating_period": framework.args.deposit_debate_seconds,
-            "prop_id": framework.next_proposal_id()
+            "debating_period": ctx.args.deposit_debate_seconds,
+            "prop_id": ctx.next_proposal_id()
         }
     )
     print(
         "Notice: Debate period is {} seconds so the test will wait "
-        "as much".format(framework.args.proposal_debate_seconds)
+        "as much".format(ctx.args.proposal_debate_seconds)
     )
 
-    framework.execute(expected={
+    ctx.execute(expected={
         "proposal_passed": True,
-        "deposit_after_vote": framework.args.deposit_new_value
+        "deposit_after_vote": ctx.args.deposit_new_value
     })

--- a/tests/scenarios/fund/run.py
+++ b/tests/scenarios/fund/run.py
@@ -3,32 +3,32 @@ from datetime import datetime
 from utils import constrained_sum_sample_pos, arr_str
 
 
-def run(framework):
+def run(ctx):
     # if deployment did not already happen do it now
-    if not framework.dao_addr:
-        framework.run_scenario('deploy')
+    if not ctx.dao_addr:
+        ctx.run_scenario('deploy')
     else:
         print(
             "WARNING: Running the funding scenario with a pre-deployed "
             "DAO contract. Closing time is {} which is approximately {} "
             "seconds from now.".format(
-                datetime.fromtimestamp(framework.closing_time).strftime(
+                datetime.fromtimestamp(ctx.closing_time).strftime(
                     '%Y-%m-%d %H:%M:%S'
                 ),
-                framework.remaining_time()
+                ctx.remaining_time()
             )
         )
 
-    sale_secs = framework.remaining_time()
-    framework.total_supply = framework.args.deploy_min_value + random.randint(1, 100)
-    framework.token_amounts = constrained_sum_sample_pos(
-        len(framework.accounts), framework.total_supply
+    sale_secs = ctx.remaining_time()
+    ctx.total_supply = ctx.args.deploy_min_value + random.randint(1, 100)
+    ctx.token_amounts = constrained_sum_sample_pos(
+        len(ctx.accounts), ctx.total_supply
     )
-    framework.create_js_file(substitutions={
-            "dao_abi": framework.dao_abi,
-            "dao_address": framework.dao_addr,
+    ctx.create_js_file(substitutions={
+            "dao_abi": ctx.dao_abi,
+            "dao_address": ctx.dao_addr,
             "wait_ms": (sale_secs-3)*1000,
-            "amounts": arr_str(framework.token_amounts)
+            "amounts": arr_str(ctx.token_amounts)
         }
     )
     print(
@@ -36,9 +36,9 @@ def run(framework):
         "as much".format(sale_secs)
     )
 
-    framework.execute(expected={
+    ctx.execute(expected={
         "dao_funded": True,
-        "total_supply": framework.total_supply,
-        "balances": framework.token_amounts,
-        "user0_after": framework.token_amounts[0],
+        "total_supply": ctx.total_supply,
+        "balances": ctx.token_amounts,
+        "user0_after": ctx.token_amounts[0],
     })

--- a/tests/scenarios/fund_fail/run.py
+++ b/tests/scenarios/fund_fail/run.py
@@ -3,41 +3,41 @@ from datetime import datetime
 from utils import constrained_sum_sample_pos, arr_str
 
 
-def run(framework):
+def run(ctx):
     # if deployment did not already happen do it now
-    if not framework.dao_addr:
-        framework.run_scenario('deploy')
+    if not ctx.dao_addr:
+        ctx.run_scenario('deploy')
     else:
         print(
             "WARNING: Running the failed funding scenario with a pre-deployed "
             "DAO contract. Closing time is {} which is approximately {} "
             "seconds from now.".format(
-                datetime.fromtimestamp(framework.closing_time).strftime(
+                datetime.fromtimestamp(ctx.closing_time).strftime(
                     '%Y-%m-%d %H:%M:%S'
                 ),
-                framework.remaining_time()
+                ctx.remaining_time()
             )
         )
 
-    accounts_num = len(framework.accounts)
-    sale_secs = framework.remaining_time()
-    framework.total_supply = random.randint(5, framework.args.deploy_min_value - 4)
-    framework.token_amounts = constrained_sum_sample_pos(
-        accounts_num, framework.total_supply
+    accounts_num = len(ctx.accounts)
+    sale_secs = ctx.remaining_time()
+    ctx.total_supply = random.randint(5, ctx.args.deploy_min_value - 4)
+    ctx.token_amounts = constrained_sum_sample_pos(
+        accounts_num, ctx.total_supply
     )
-    framework.create_js_file(substitutions={
-            "dao_abi": framework.dao_abi,
-            "dao_address": framework.dao_addr,
+    ctx.create_js_file(substitutions={
+            "dao_abi": ctx.dao_abi,
+            "dao_address": ctx.dao_addr,
             "wait_ms": (sale_secs-3)*1000,
-            "amounts": arr_str(framework.token_amounts)
+            "amounts": arr_str(ctx.token_amounts)
         }
     )
     print(
         "Notice: Funding period is {} seconds so the test will wait "
         "as much".format(sale_secs)
     )
-    framework.execute(expected={
+    ctx.execute(expected={
         "dao_funded": False,
-        "total_supply": framework.total_supply,
-        "refund": framework.token_amounts
+        "total_supply": ctx.total_supply,
+        "refund": ctx.token_amounts
     })

--- a/tests/scenarios/fund_fail2/run.py
+++ b/tests/scenarios/fund_fail2/run.py
@@ -3,43 +3,43 @@ from datetime import datetime
 from utils import constrained_sum_sample_pos, arr_str
 
 
-def run(framework):
+def run(ctx):
     # if deployment did not already happen do it now
-    if not framework.dao_addr:
-        framework.run_scenario('deploy')
+    if not ctx.dao_addr:
+        ctx.run_scenario('deploy')
     else:
         print(
             "WARNING: Running the failed funding 2 scenario with a "
             "pre-deployed DAO contract. Closing time is {} which is "
             "approximately {} seconds from now.".format(
-                datetime.fromtimestamp(framework.closing_time).strftime(
+                datetime.fromtimestamp(ctx.closing_time).strftime(
                     '%Y-%m-%d %H:%M:%S'
                 ),
-                framework.remaining_time()
+                ctx.remaining_time()
             )
         )
 
-    accounts_num = len(framework.accounts)
-    if accounts_num * 2 >= framework.args.deploy_min_value - 4:
+    accounts_num = len(ctx.accounts)
+    if accounts_num * 2 >= ctx.args.deploy_min_value - 4:
         print("Please increase the minimum funding goal for the scenario.")
         sys.exit(1)
 
-    sale_secs = framework.remaining_time()
-    total_supply = framework.args.deploy_min_value - 4
+    sale_secs = ctx.remaining_time()
+    total_supply = ctx.args.deploy_min_value - 4
     proxy_amounts = constrained_sum_sample_pos(
         accounts_num, total_supply / 2
     )
     normal_amounts = constrained_sum_sample_pos(
         accounts_num, total_supply / 2
     )
-    framework.token_amounts = [
+    ctx.token_amounts = [
         sum(x) for x in zip(proxy_amounts[::-1], normal_amounts)
     ]
-    framework.total_supply = sum(framework.token_amounts)
-    framework.create_js_file(
+    ctx.total_supply = sum(ctx.token_amounts)
+    ctx.create_js_file(
         substitutions={
-            "dao_abi": framework.dao_abi,
-            "dao_address": framework.dao_addr,
+            "dao_abi": ctx.dao_abi,
+            "dao_address": ctx.dao_addr,
             "wait_ms": (sale_secs-3)*1000,
             "proxy_amounts": arr_str(proxy_amounts),
             "normal_amounts": arr_str(normal_amounts)
@@ -49,8 +49,8 @@ def run(framework):
         "Notice: Funding period is {} seconds so the test will wait "
         "as much".format(sale_secs)
     )
-    framework.execute(expected={
+    ctx.execute(expected={
         "dao_funded": False,
-        "total_supply": framework.total_supply,
-        "refund": framework.token_amounts
+        "total_supply": ctx.total_supply,
+        "refund": ctx.token_amounts
     })

--- a/tests/scenarios/proposal/run.py
+++ b/tests/scenarios/proposal/run.py
@@ -14,44 +14,44 @@ def count_token_votes(amounts, votes):
     return yay, nay
 
 
-def run(framework):
-    if not framework.token_amounts:
+def run(ctx):
+    if not ctx.token_amounts:
         # run the funding scenario first
-        framework.run_scenario('fund')
+        ctx.run_scenario('fund')
 
     minamount = 2  # is determined by the total costs + one time costs
-    amount = random.randint(minamount, sum(framework.token_amounts))
+    amount = random.randint(minamount, sum(ctx.token_amounts))
     votes = create_votes_array(
-        framework.token_amounts,
-        not framework.args.proposal_fail
+        ctx.token_amounts,
+        not ctx.args.proposal_fail
     )
-    yay, nay = count_token_votes(framework.token_amounts, votes)
-    framework.create_js_file(substitutions={
-            "dao_abi": framework.dao_abi,
-            "dao_address": framework.dao_addr,
-            "offer_abi": framework.offer_abi,
-            "offer_address": framework.offer_addr,
+    yay, nay = count_token_votes(ctx.token_amounts, votes)
+    ctx.create_js_file(substitutions={
+            "dao_abi": ctx.dao_abi,
+            "dao_address": ctx.dao_addr,
+            "offer_abi": ctx.offer_abi,
+            "offer_address": ctx.offer_addr,
             "offer_amount": amount,
             "offer_desc": 'Test Proposal',
-            "proposal_deposit": framework.args.proposal_deposit,
+            "proposal_deposit": ctx.args.proposal_deposit,
             "transaction_bytecode": '0x2ca15122',  # solc --hashes SampleOffer.sol
-            "debating_period": framework.args.proposal_debate_seconds,
+            "debating_period": ctx.args.proposal_debate_seconds,
             "votes": arr_str(votes)
         }
     )
     print(
         "Notice: Debate period is {} seconds so the test will wait "
-        "as much".format(framework.args.proposal_debate_seconds)
+        "as much".format(ctx.args.proposal_debate_seconds)
     )
 
-    framework.execute(expected={
+    ctx.execute(expected={
         "dao_proposals_number": "1",
         "proposal_passed": True,
         "proposal_yay": yay,
         "proposal_nay": nay,
-        "calculated_deposit": framework.args.proposal_deposit,
-        "onetime_costs": framework.args.deploy_onetime_costs,
+        "calculated_deposit": ctx.args.proposal_deposit,
+        "onetime_costs": ctx.args.deploy_onetime_costs,
         "deposit_returned": True,
         "offer_promise_valid": True
     })
-    framework.prop_id = 1
+    ctx.prop_id = 1

--- a/tests/scenarios/rewards/run.py
+++ b/tests/scenarios/rewards/run.py
@@ -3,31 +3,31 @@ def calculate_reward(tokens, total_tokens, total_rewards):
     return result
 
 
-def run(framework):
-    if not framework.prop_id:
+def run(ctx):
+    if not ctx.prop_id:
         # run the proposal scenario first
-        framework.run_scenario('proposal')
+        ctx.run_scenario('proposal')
 
-    framework.create_js_file(substitutions={
-            "dao_abi": framework.dao_abi,
-            "dao_address": framework.dao_addr,
-            "total_rewards": framework.args.rewards_total_amount,
-            "proposal_deposit": framework.args.proposal_deposit,
+    ctx.create_js_file(substitutions={
+            "dao_abi": ctx.dao_abi,
+            "dao_address": ctx.dao_addr,
+            "total_rewards": ctx.args.rewards_total_amount,
+            "proposal_deposit": ctx.args.proposal_deposit,
             "transaction_bytecode": '0x0',  # fallback function
-            "debating_period": framework.args.proposal_debate_seconds,
-            "prop_id": framework.next_proposal_id()
+            "debating_period": ctx.args.proposal_debate_seconds,
+            "prop_id": ctx.next_proposal_id()
         }
     )
     print(
         "Notice: Debate period is {} seconds so the test will wait "
-        "as much".format(framework.args.proposal_debate_seconds)
+        "as much".format(ctx.args.proposal_debate_seconds)
     )
 
-    results = framework.execute(expected={
+    results = ctx.execute(expected={
         "provider_reward_portion": calculate_reward(
-            framework.token_amounts[0],
-            framework.total_supply,
-            framework.args.rewards_total_amount)
+            ctx.token_amounts[0],
+            ctx.total_supply,
+            ctx.args.rewards_total_amount)
     })
-    framework.dao_balance_after_rewards = results['DAO_balance']
-    framework.dao_rewardToken_after_rewards = results['DAO_rewardToken']
+    ctx.dao_balance_after_rewards = results['DAO_balance']
+    ctx.dao_rewardToken_after_rewards = results['DAO_rewardToken']

--- a/tests/scenarios/singlesplit/run.py
+++ b/tests/scenarios/singlesplit/run.py
@@ -1,22 +1,22 @@
-def run(framework):
-    if not framework.token_amounts:
+def run(ctx):
+    if not ctx.token_amounts:
         # run the funding scenario first
-        framework.run_scenario('fund')
+        ctx.run_scenario('fund')
 
-    framework.create_js_file(substitutions={
-        "dao_abi": framework.dao_abi,
-        "dao_address": framework.dao_addr,
-        "proposal_deposit": framework.args.proposal_deposit,
+    ctx.create_js_file(substitutions={
+        "dao_abi": ctx.dao_abi,
+        "dao_address": ctx.dao_addr,
+        "proposal_deposit": ctx.args.proposal_deposit,
         "split_gas": 4000000,
-        "debating_period": framework.args.proposal_debate_seconds,
-        "prop_id": framework.next_proposal_id()
+        "debating_period": ctx.args.proposal_debate_seconds,
+        "prop_id": ctx.next_proposal_id()
     })
     print(
         "Notice: Debate period is {} seconds so the test will wait "
-        "as much".format(framework.args.proposal_debate_seconds)
+        "as much".format(ctx.args.proposal_debate_seconds)
     )
 
-    framework.execute(expected={
+    ctx.execute(expected={
         "newdao_proposals_num": 1,
-        "angry_user_profit": framework.token_amounts[1] + framework.args.proposal_deposit
+        "angry_user_profit": ctx.token_amounts[1] + ctx.args.proposal_deposit
     })

--- a/tests/scenarios/singlesplit/run.py
+++ b/tests/scenarios/singlesplit/run.py
@@ -1,0 +1,22 @@
+def run(framework):
+    if not framework.token_amounts:
+        # run the funding scenario first
+        framework.run_scenario('fund')
+
+    framework.create_js_file(substitutions={
+        "dao_abi": framework.dao_abi,
+        "dao_address": framework.dao_addr,
+        "proposal_deposit": framework.args.proposal_deposit,
+        "split_gas": 4000000,
+        "debating_period": framework.args.proposal_debate_seconds,
+        "prop_id": framework.next_proposal_id()
+    })
+    print(
+        "Notice: Debate period is {} seconds so the test will wait "
+        "as much".format(framework.args.proposal_debate_seconds)
+    )
+
+    framework.execute(expected={
+        "newdao_proposals_num": 1,
+        "angry_user_profit": framework.token_amounts[1] + framework.args.proposal_deposit
+    })

--- a/tests/scenarios/singlesplit/template.js
+++ b/tests/scenarios/singlesplit/template.js
@@ -1,0 +1,124 @@
+var dao = web3.eth.contract($dao_abi).at('$dao_address');
+var newServiceProvider = eth.accounts[1];
+
+
+console.log("Our disgruntled user is creating proposal to change SP to itself...");
+var tx_hash = null;
+dao.newProposal.sendTransaction(
+    newServiceProvider, // new SP
+    0,
+    'eth.accounts[1] wants to split out',
+    '',
+    $debating_period,
+    true,
+    {
+        from: newServiceProvider,
+        gas: 1000000
+    }
+    , function (e, res) {
+        if (e) {
+            console.log(e + "at newProposal()!");
+        } else {
+            tx_hash = res;
+            console.log("newProposal tx hash is: " + tx_hash);
+        }
+    }
+);
+checkWork();
+
+var prop_id = $prop_id;
+console.log("Voting for split proposal '" + prop_id + "' ...");
+for (i = 0; i < eth.accounts.length; i++) {
+    dao.vote.sendTransaction(
+        prop_id,
+        i == 1 ? true : false,
+        {
+            from: eth.accounts[i],
+            gas: 1000000
+        }
+    );
+}
+checkWork();
+addToTest('proposal_yay', parseInt(web3.fromWei(dao.proposals(prop_id)[9])));
+addToTest('proposal_nay', parseInt(web3.fromWei(dao.proposals(prop_id)[10])));
+
+setTimeout(function() {
+    miner.stop(0);
+    console.log("Executing the split proposal...");
+    // now our disgruntled user is the only one to execute the splitDAO function
+    dao.splitDAO.sendTransaction(
+        prop_id,
+        newServiceProvider,
+        {from:newServiceProvider, gas: $split_gas}
+    );
+    checkWork();
+    console.log("After split execution");
+    addToTest('proposal_passed', dao.proposals(prop_id)[5]);
+    addToTest('proposal_newdao', dao.splitProposalNewAddress(prop_id, 0));
+
+    var newdao = web3.eth.contract($dao_abi).at(testMap['proposal_newdao']);
+    // check token balance of each user in both DAOs
+    oldDAOBalance = [];
+    newDAOBalance = [];
+    for (i = 0; i < eth.accounts.length; i++) {
+        oldDAOBalance.push(parseInt(web3.fromWei(dao.balanceOf(eth.accounts[i]))));
+        newDAOBalance.push(parseInt(web3.fromWei(newdao.balanceOf(eth.accounts[i]))));
+    }
+    addToTest('oldDAOBalance', oldDAOBalance);
+    addToTest('newDAOBalance', newDAOBalance);
+    addToTest('newDAOTotalSupply', parseInt(web3.fromWei(newdao.totalSupply())));
+
+    setTimeout(function() {
+        // now our disgruntled user has his own DAO and is the SP of that DAO so ...
+        console.log("Angry user proposes to his own DAO to send all funds to himself...");
+        newdao.newProposal.sendTransaction(
+            newServiceProvider,
+            newdao.totalSupply(),
+            'Send all money to myself!! Screw you guys ... I am going home!',
+            '0x0', // bytecode, not needed here, calling the fallback function
+            $debating_period,
+            false,
+            {
+                from: newServiceProvider,
+                value: web3.toWei($proposal_deposit, "ether"),
+                gas: 1000000
+            }
+            , function (e, res) {
+                if (e) {
+                    console.log(e + "at newProposal()!");
+                } else {
+                    tx_hash = res;
+                    console.log("SOLO MOVE proposal tx hash is: " + tx_hash);
+                }
+            }
+        );
+        checkWork();
+        console.log("Angry user votes in his own DAO...");
+        newdao.vote.sendTransaction(
+            1,
+            true,
+            {
+                from: newServiceProvider,
+                gas: 1000000
+            }
+        );
+        checkWork();
+        addToTest('newdao_proposals_num', newdao.numberOfProposals());
+        addToTest('angry_user_before', web3.fromWei(eth.getBalance(newServiceProvider)));
+        setTimeout(function() {
+            addToTest('newdao_proposal_passed', newdao.proposals(1)[5]);
+            // now execute the proposal
+            newdao.executeProposal.sendTransaction(1, '0x0', {from:newServiceProvider, gas:1000000});
+            checkWork();
+            addToTest('angry_user_after', web3.fromWei(eth.getBalance(newServiceProvider)));
+            addToTest(
+                'angry_user_profit',
+                bigDiffRound(testMap['angry_user_after'], testMap['angry_user_before'])
+            );
+            testResults();
+        }, $debating_period * 1000);
+        console.log("Wait for end of second debating period");
+    }, 20 * 1000);
+    console.log("Wait for new DAO funding period to end");
+}, $debating_period * 1000);
+console.log("Wait for end of first debating period");

--- a/tests/scenarios/split/run.py
+++ b/tests/scenarios/split/run.py
@@ -57,32 +57,32 @@ def tokens_after_split(votes, original_balance, dao_balance, reward_tokens):
     )
 
 
-def prepare_test_split(framework, split_gas):
-    if framework.prop_id != 2:
+def prepare_test_split(ctx, split_gas):
+    if ctx.prop_id != 2:
         # run the rewards scenario first
-        framework.run_scenario('rewards')
+        ctx.run_scenario('rewards')
 
     votes = create_votes_array(
-        framework.token_amounts,
-        not framework.args.proposal_fail
+        ctx.token_amounts,
+        not ctx.args.proposal_fail
     )
-    framework.create_js_file(substitutions={
-            "dao_abi": framework.dao_abi,
-            "dao_address": framework.dao_addr,
-            "debating_period": framework.args.split_debate_seconds,
+    ctx.create_js_file(substitutions={
+            "dao_abi": ctx.dao_abi,
+            "dao_address": ctx.dao_addr,
+            "debating_period": ctx.args.split_debate_seconds,
             "split_gas": split_gas,
             "votes": arr_str(votes),
-            "prop_id": framework.next_proposal_id()
+            "prop_id": ctx.next_proposal_id()
         }
     )
     print(
         "Notice: Debate period is {} seconds so the test will wait "
-        "as much".format(framework.args.split_debate_seconds)
+        "as much".format(ctx.args.split_debate_seconds)
     )
     return votes
 
 
-def run(framework):
+def run(ctx):
     # Use the split_gas variable to test that splitting with insufficient gas,
     # will fail reliably and will not leave an empty contract in the state,
     # burning away user tokens in the process.
@@ -90,15 +90,15 @@ def run(framework):
     # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.mediawiki#specification
     split_gas = 4000000
 
-    votes = prepare_test_split(framework, split_gas)
+    votes = prepare_test_split(ctx, split_gas)
     oldBalance, newBalance, oldDAORewards, newDAORewards = tokens_after_split(
         votes,
-        framework.token_amounts,
-        framework.dao_balance_after_rewards,
-        framework.dao_rewardToken_after_rewards
+        ctx.token_amounts,
+        ctx.dao_balance_after_rewards,
+        ctx.dao_rewardToken_after_rewards
     )
 
-    framework.execute(expected={
+    ctx.execute(expected={
         # default deposit,a simple way to test new DAO contract got created
         "newDAOProposalDeposit": 20,
         "oldDAOBalance": oldBalance,

--- a/tests/scenarios/split/template.js
+++ b/tests/scenarios/split/template.js
@@ -1,7 +1,6 @@
 var dao = web3.eth.contract($dao_abi).at('$dao_address');
 var newServiceProvider = eth.accounts[1];
 
-// create a new proposal for sending this whole donation to the rewardAccount
 console.log("Creating proposal to change SP...");
 var tx_hash = null;
 dao.newProposal.sendTransaction(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -118,6 +118,10 @@ def compare_values(a, b):
         return False
     if isinstance(a, float):
         return abs(a - b) <= 0.01
+    elif isinstance(a, basestring) and isinstance(b, int):
+        return int(a) == b
+    elif isinstance(b, basestring) and isinstance(a, int):
+        return a == int(b)
     else:
         return a == b
 
@@ -219,6 +223,10 @@ def edit_dao_source(contracts_dir, keep_limits):
         contents = contents.replace(" || (_debatingPeriod < 2 weeks)", "")
         contents = contents.replace("|| now > p.votingDeadline + 41 days", "")
         contents = contents.replace("now < closingTime + 40 days", "true")
+        contents = contents.replace(
+            "daoCreator.createDAO(_newServiceProvider, 0, now + 42 days);",
+            "daoCreator.createDAO(_newServiceProvider, 0, now + 20);"
+        )
 
     # add test query functions
     contents = contents.replace(


### PR DESCRIPTION
- Adding the single user split scenario where one angry user is voting
  to add himself as the ServiceProvider, splitting into his own DAO and
  eventually transferring all of the new DAO's funds to himself.

- When the testing framework compares string to int or vice versa it will
  now attempt a conversion.

- Rename framework variable to ctx (context), in the scenarios to improve
  code usability/readability