### PR TITLE
Set the homestead block to begin at Zero

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -179,6 +179,9 @@ def write_js(name, contents, accounts_num):
 def create_genesis(accounts):
     """Create a genesis block with ether allocation for the given accounts"""
     genesis = {}
+    config = {}
+    config["homesteadBlock"] = "0"
+    genesis["config"] = config
     genesis["nonce"] = "0xdeadbeefdeadbeef"
     genesis["timestamp"] = "0x0"
     # Start after homesteam


### PR DESCRIPTION
Thanks to this PR in geth:
https://github.com/ethereum/go-ethereum/pull/2281 we can now set from
which block we would like homestead to begin.