### PR TITLE
Check call() at newContract() before moving tokens

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -607,7 +607,9 @@ contract DAO is DAOInterface, Token, TokenSale {
     function newContract(address _newContract){
         if (msg.sender != address(this) || !allowedRecipients[_newContract]) return;
         // move all funds
-        _newContract.call.value(address(this).balance)();
+        if (!_newContract.call.value(address(this).balance)()) {
+            throw;
+        }
 
         //move all reward tokens
         rewardToken[_newContract] += rewardToken[address(this)];


### PR DESCRIPTION
The `call()` to transfer all funds to a new contract could potentially
return an error (eg: stack depth limit reached) and not work, but
without a check the code would happily continue and burn the tokens.