### PR TITLE
Constants and readability

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -361,7 +361,7 @@ contract DAO is DAOInterface, Token, TokenSale {
             throw;
         lastTimeMinQuorumMet = now;
         minQuorumDivisor = 5; // sets the minimal quorum to 20%
-        proposals.length++; // avoids a proposal with ID 0 because it is used
+        proposals.length = 1; // avoids a proposal with ID 0 because it is used
 
         allowedRecipients[address(this)] = true;
     }


### PR DESCRIPTION
- Move all hardcoded values as constants in the top of the contract
- Explicitly set proposals.length in the constructor, it's more readable this way.
- Fixed a timestamp bug. `28` != `28 days`