### PR TITLE
Avoid blocked token because of throwing calls

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -37,7 +37,7 @@ contract DAOInterface {
     uint constant splitExecutionPeriod = 27 days;
     // Period of time after which the minimum Quorum is halved
     uint constant quorumHalvingPeriod = 52 weeks;
-    // Period after which a propsal can be closed (used in the case `executeProposal`
+    // Period after which a proposal can be closed (used in the case `executeProposal`
     // fails because it throws)
     uint constant executeProposalPeriod = 5 days;
 

--- a/DAO.sol
+++ b/DAO.sol
@@ -497,6 +497,7 @@ contract DAO is DAOInterface, Token, TokenSale {
         bytes _transactionData
     ) noEther returns (bool _success) {
 
+        stackDepthControl();
         Proposal p = proposals[_proposalID];
 
         if (p.newCurator) {
@@ -821,6 +822,17 @@ contract DAO is DAOInterface, Token, TokenSale {
     function createNewDAO(address _newCurator) internal returns (DAO _newDAO) {
         NewCurator(_newCurator);
         return daoCreator.createDAO(_newCurator, 0, 0, now + splitExecutionPeriod);
+    }
+
+    uint stackDepthControlTmp;
+
+    function stackDepthControl() returns (bool) {
+        if (stackDepthControlTmp++ < 16){
+            if (!DAO(this).stackDepthControl())
+                throw;
+        }
+        stackDepthControlTmp = 0;
+        return true;
     }
 
 

--- a/DAO.sol
+++ b/DAO.sol
@@ -849,7 +849,7 @@ contract DAO is DAOInterface, Token, TokenSale {
         if (blocked[_account] == 0)
             return false;
         Proposal p = proposals[blocked[_account]];
-        if (now >= p.votingDeadline) {
+        if (now > p.votingDeadline) {
             blocked[_account] = 0;
             return false;
         } else {

--- a/DAO.sol
+++ b/DAO.sol
@@ -233,6 +233,12 @@ contract DAOInterface {
         bytes _transactionData
     ) returns (bool _success);
 
+    /// @notice close the proposal (used in the case `executeProposal`
+    /// fails because it throws)
+    /// @param _proposalID The proposal ID
+    function emergenyCloseProposal(uint _proposalID) external;
+
+
     /// @notice ATTENTION! I confirm to move my remaining ether to a new DAO
     /// with `_newCurator` as the new Curator, as has been
     /// proposed in proposal `_proposalID`. This will burn my tokens. This can

--- a/DAO.sol
+++ b/DAO.sol
@@ -532,7 +532,6 @@ contract DAO is DAOInterface, Token, TokenSale {
         uint quorum = p.yea + p.nay;
 
         // require 53% for calling newContract()
-
         if (_transactionData.length >= 4 && _transactionData[0] == 0x68
             && _transactionData[1] == 0x37 && _transactionData[2] == 0xff
             && _transactionData[3] == 0x1e
@@ -573,7 +572,6 @@ contract DAO is DAOInterface, Token, TokenSale {
         sumOfProposalDeposits -= p.proposalDeposit;
         p.open = false;
     }
-
 
     function splitDAO(
         uint _proposalID,

--- a/DAO.sol
+++ b/DAO.sol
@@ -508,7 +508,7 @@ contract DAO is DAOInterface, Token, TokenSale {
 
         // If the curator removed the recipient from the whitelist, close the proposal
         // in order to free the deposit and allow unblocking of voters
-        if (!allowedRecipients[p.recipient]) {
+        if (!allowedRecipients[p.recipient] && p.open) {
             closeProposal(_proposalID);
             p.creator.send(p.proposalDeposit);
             return;
@@ -569,8 +569,15 @@ contract DAO is DAOInterface, Token, TokenSale {
 
     function closeProposal(uint _proposalID) internal {
         Proposal p = proposals[_proposalID];
-        sumOfProposalDeposits -= p.proposalDeposit;
+        if (p.open)
+            sumOfProposalDeposits -= p.proposalDeposit;
         p.open = false;
+    }
+
+    function emergenyCloseProposal(uint _proposalID) external {
+        Proposal p = proposals[_proposalID];
+        if (p.votingDeadline + 5 days < now && p.open)
+            closeProposal(_proposalID);
     }
 
     function splitDAO(


### PR DESCRIPTION
The problem is, in the case `executeProposal` throws, all the tokens that have voted are blocked forever (big problem).
Here some scenarios:
1) the fallback function of the creator of the proposal throws ( I would consider it an attack to create a proposal with an address that has a fallback function that can throw)
2) the called recipient functions throws
3) another proposal got accepted in the meantime, and the DAO doesn't has enough funds to execute the proposal

This PR solves 1) by letting the curators close a proposal by removing it from the whitelist.
2) and 3) are solved by not throwing anymore but just closing the proposal.