### PR TITLE
log event AllowedRecipientChanged

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -338,7 +338,7 @@ contract DAOInterface {
     event Voted(uint indexed proposalID, bool position, address indexed voter);
     event ProposalTallied(uint indexed proposalID, bool result, uint quorum);
     event NewCurator(address indexed _newCurator);
-    event AllowedRecipientAdded(address indexed _recipient);
+    event AllowedRecipientChanged(address indexed _recipient, bool _allowed);
 }
 
 // The DAO contract itself
@@ -792,6 +792,7 @@ contract DAO is DAOInterface, Token, TokenSale {
         if (msg.sender != curator)
             throw;
         allowedRecipients[_recipient] = _allowed;
+        AllowedRecipientChanged(_recipient, _allowed);
         return true;
     }
 


### PR DESCRIPTION
Before this commit an event `AllowedRecipientAdded` was declared but never used.  Since now allowed recipients can both be added and removed, I changed the name of the event.  And the event is logged.