### PR TITLE
Rename minValue to better reflect fueling goal

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -154,7 +154,8 @@ contract DAOInterface {
     /// @param _curator The Curator
     /// @param _daoCreator The contract able to (re)create this DAO
     /// @param _proposalDeposit The deposit to be paid for a regular proposal
-    /// @param _minValue Minimal value for a successful DAO Token Creation
+    /// @param _minTokensToCreate Minimum required wei-equivalent tokens
+    ///        to be created for a successful DAO Token Creation
     /// @param _closingTime Date (in Unix time) of the end of the DAO Token Creation
     /// @param _privateCreation If zero the DAO Token Creation is open to public, a
     /// non-zero address means that the DAO Token Creation is only for the address
@@ -163,7 +164,7 @@ contract DAOInterface {
         //  address _curator,
         //  DAO_Creator _daoCreator,
         //  uint _proposalDeposit,
-        //  uint _minValue,
+        //  uint _minTokensToCreate,
         //  uint _closingTime,
         //  address _privateCreation
     //  );
@@ -357,10 +358,10 @@ contract DAO is DAOInterface, Token, TokenCreation {
         address _curator,
         DAO_Creator _daoCreator,
         uint _proposalDeposit,
-        uint _minValue,
+        uint _minTokensToCreate,
         uint _closingTime,
         address _privateCreation
-    ) TokenCreation(_minValue, _closingTime, _privateCreation) {
+    ) TokenCreation(_minTokensToCreate, _closingTime, _privateCreation) {
 
         curator = _curator;
         daoCreator = _daoCreator;
@@ -869,7 +870,7 @@ contract DAO_Creator {
     function createDAO(
         address _curator,
         uint _proposalDeposit,
-        uint _minValue,
+        uint _minTokensToCreate,
         uint _closingTime
     ) returns (DAO _newDAO) {
 
@@ -877,7 +878,7 @@ contract DAO_Creator {
             _curator,
             DAO_Creator(this),
             _proposalDeposit,
-            _minValue,
+            _minTokensToCreate,
             _closingTime,
             msg.sender
         );

--- a/Token.sol
+++ b/Token.sol
@@ -34,7 +34,7 @@ contract TokenInterface {
     mapping (address => uint256) balances;
     mapping (address => mapping (address => uint256)) allowed;
 
-    /// @return Total amount of tokens
+    /// Total amount of tokens
     uint256 public totalSupply;
 
     /// @param _owner The address from which the balance will be retrieved

--- a/TokenCreation.sol
+++ b/TokenCreation.sol
@@ -29,8 +29,9 @@ contract TokenCreationInterface {
 
     // End of token creation, in Unix time
     uint public closingTime;
-    // Minimum fueling goal of the token creation, denominated in ether
-    uint public minValue;
+    // Minimum fueling goal of the token creation, denominated in tokens to
+    // be created
+    uint public minTokensToCreate;
     // True if the DAO reached its minimum fueling goal, false otherwise
     bool public isFueled;
     // For DAO splits - if privateCreation is 0, then it is a public token
@@ -45,14 +46,15 @@ contract TokenCreationInterface {
 
     /// @dev Constructor setting the minimum fueling goal and the
     /// end of the Token Creation
-    /// @param _minValue Token Creation minimum fueling goal
+    /// @param _minTokensToCreate Minimum fueling goal in number of
+    ///        Tokens to be created
     /// @param _closingTime Date (in Unix time) of the end of the Token Creation
     /// @param _privateCreation Zero means that the creation is public.  A
     /// non-zero address represents the only address that can create Tokens
     /// (the address can also create Tokens on behalf of other accounts)
     // This is the constructor: it can not be overloaded so it is commented out
     //  function TokenCreation(
-        //  uint _minValue,
+        //  uint _minTokensTocreate,
         //  uint _closingTime,
         //  address _privateCreation
     //  );
@@ -77,9 +79,13 @@ contract TokenCreationInterface {
 
 
 contract TokenCreation is TokenCreationInterface, Token {
-    function TokenCreation(uint _minValue, uint _closingTime, address _privateCreation) {
+    function TokenCreation(
+        uint _minTokensToCreate,
+        uint _closingTime,
+        address _privateCreation) {
+
         closingTime = _closingTime;
-        minValue = _minValue;
+        minTokensToCreate = _minTokensToCreate;
         privateCreation = _privateCreation;
         extraBalance = new ManagedAccount(address(this), true);
     }
@@ -94,7 +100,7 @@ contract TokenCreation is TokenCreationInterface, Token {
             totalSupply += token;
             weiGiven[_tokenHolder] += msg.value;
             CreatedToken(_tokenHolder, token);
-            if (totalSupply >= minValue && !isFueled) {
+            if (totalSupply >= minTokensToCreate && !isFueled) {
                 isFueled = true;
                 FuelingToDate(totalSupply);
             }

--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -4,7 +4,7 @@
 
 personal.unlockAccount(eth.accounts[0]);
 var daoContract = web3.eth.contract(dao_abi);
-var min_value = 1;
+var min_tokens_to_create = 1;
 var closing_time = Math.floor(Date.now() / 1000) + seconds_from_now;
 
 var creatorContract = web3.eth.contract(creator_abi);
@@ -23,7 +23,7 @@ var _daoCreatorContract = creatorContract.new(
 	            curator,
 	            contract.address,
                 web3.toWei(default_proposal_deposit, "ether"),
-	            web3.toWei(min_value, "ether"),
+	            web3.toWei(min_tokens_to_create, "ether"),
                 closing_time,
                 0,
 		        {

--- a/paper/Paper.tex
+++ b/paper/Paper.tex
@@ -205,13 +205,13 @@ The event \verb|Approval| is used to inform lightweight clients about changes in
 \begin{verbatim}
 contract TokenCreationInterface {
     uint public closingTime;   
-    uint public minValue;  
+    uint public minTokensToCreate;
     bool public isFueled;
     address public privateCreation;
     ManagedAccount extraBalance;
     mapping (address => uint256) weiGiven;
 
-    function TokenCreation(uint _minValue, uint _closingTime);
+    function TokenCreation(uint _minTokensToCreate, uint _closingTime);
     function createTokenProxy(address _tokenHolder) returns (bool success);
     function refund();
     function divisor() returns (uint divisor);
@@ -226,7 +226,7 @@ Above is the interface of the \verb|TokenCreation| contract (\ref{app:TokenCreat
 
 The integer \verb|closingTime| is the (unix) time at which the Creation Phase ends.
 
-The integer \verb|minValue| is the number of wei which are needed to be received by the DAO in order to get funded.
+The integer \verb|minTokensToCreate| is the number of wei-equivalent tokens which are needed to be created by the DAO in order to be considered fueled.
 
 The boolean \verb|isFueled| is true if DAO has reached its minimum fueling goal, false otherwise.
 
@@ -236,7 +236,7 @@ The managed account (\ref{app:ManagedAccount}) \verb|extraBalance| is used to ho
 
 The map \verb|weiGiven| stores the amount of wei given by each contributor during the Creation Phase and is only used to refund the contributors if the Creation Phase does not reach its fueling goal.
 
-The constructor \verb|TokenCreation| initiates the Creation Phase with the arguments \verb|minValue|, \verb|closingtime| and \verb|privateCreation|, which will be set in the constructor of the DAO contract (\ref{app:DAO}) which is only executed once, when the DAO is deployed. 
+The constructor \verb|TokenCreation| initiates the Creation Phase with the arguments \verb|minTokensToCreate|, \verb|closingtime| and \verb|privateCreation|, which will be set in the constructor of the DAO contract (\ref{app:DAO}) which is only executed once, when the DAO is deployed. 
 In order to interact with the contract the following functions can be used:
 
 \subsubsection*{createTokenProxy}
@@ -302,7 +302,7 @@ contract DAOInterface {
         address _curator,
         DAO_Creator _daoCreator,
         uint _proposalDeposit,
-        uint _minValue,
+        uint _minTokensToCreate,
         uint _closingTime,
         address _privateCreation
     )
@@ -440,7 +440,7 @@ In the DAO constructor, the following variables are set:
  \item \verb|proposalDeposit|
  \item \verb|rewardAccount|
  \item \verb|DAOrewardAccount|
- \item \verb|minValue|
+ \item \verb|minTokensToCreate|
  \item \verb|closingTime|
  \item \verb|privateCreation|
  \item \verb|lastTimeMinQuorumMet|
@@ -788,8 +788,9 @@ contract TokenCreationInterface {
 
     // End of token creation, in Unix time
     uint public closingTime;
-    // Minimum fueling goal of the token creation, denominated in ether
-    uint public minValue;
+    // Minimum fueling goal of the token creation, denominated in tokens to
+    // be created
+    uint public minTokensToCreate;
     // True if the DAO reached its minimum fueling goal, false otherwise
     bool public isFueled;
     // For DAO splits - if privateCreation is 0, then it is a public token
@@ -804,14 +805,15 @@ contract TokenCreationInterface {
 
     /// @dev Constructor setting the minimum fueling goal and the
     /// end of the Token Creation
-    /// @param _minValue Token Creation minimum fueling goal
+    /// @param _minTokensToCreate Minimum required wei-equivalent tokens
+    ///        to be created for a successful DAO Token Creation
     /// @param _closingTime Date (in Unix time) of the end of the Token Creation
     /// @param _privateCreation Zero means that the creation is public.  A
     /// non-zero address represents the only address that can create Tokens
     /// (the address can also create Tokens on behalf of other accounts)
     // This is the constructor: it can not be overloaded so it is commented out
     //  function TokenCreation(
-        //  uint _minValue,
+        //  uint _minTokensTocreate,
         //  uint _closingTime,
         //  address _privateCreation
     //  );
@@ -836,11 +838,15 @@ contract TokenCreationInterface {
 
 
 contract TokenCreation is TokenCreationInterface, Token {
-    function TokenCreation(uint _minValue, uint _closingTime, address _privateCreation) {
+    function TokenCreation(
+        uint _minTokensToCreate,
+        uint _closingTime,
+        address _privateCreation) {
+
         closingTime = _closingTime;
-        minValue = _minValue;
+        minTokensToCreate = _minTokensToCreate;
         privateCreation = _privateCreation;
-        extraBalance = new ManagedAccount(address(this));
+        extraBalance = new ManagedAccount(address(this), true);
     }
 
     function createTokenProxy(address _tokenHolder) returns (bool success) {
@@ -853,7 +859,7 @@ contract TokenCreation is TokenCreationInterface, Token {
             totalSupply += token;
             weiGiven[_tokenHolder] += msg.value;
             CreatedToken(_tokenHolder, token);
-            if (totalSupply >= minValue && !isFueled) {
+            if (totalSupply >= minTokensToCreate && !isFueled) {
                 isFueled = true;
                 FuelingToDate(totalSupply);
             }
@@ -1025,7 +1031,8 @@ contract DAOInterface {
     /// @param _curator The Curator
     /// @param _daoCreator The contract able to (re)create this DAO
     /// @param _proposalDeposit The deposit to be paid for a regular proposal
-    /// @param _minValue Minimal value for a successful DAO Token Creation
+    /// @param _minTokensToCreate Minimum required tokens to be created
+    ///        for a successful DAO Token Creation
     /// @param _closingTime Date (in Unix time) of the end of the DAO Token Creation
     /// @param _privateCreation If zero the DAO Token Creation is open to public, a
     /// non-zero address means that the DAO Token Creation is only for the address
@@ -1034,7 +1041,7 @@ contract DAOInterface {
         //  address _curator,
         //  DAO_Creator _daoCreator,
         //  uint _proposalDeposit,
-        //  uint _minValue,
+        //  uint _minTokensToCreate,
         //  uint _closingTime,
         //  address _privateCreation
     //  );
@@ -1228,16 +1235,16 @@ contract DAO is DAOInterface, Token, TokenCreation {
         address _curator,
         DAO_Creator _daoCreator,
         uint _proposalDeposit,
-        uint _minValue,
+        uint _minTokensToCreate,
         uint _closingTime,
         address _privateCreation
-    ) TokenCreation(_minValue, _closingTime, _privateCreation) {
+    ) TokenCreation(_minTokensToCreate, _closingTime, _privateCreation) {
 
         curator = _curator;
         daoCreator = _daoCreator;
         proposalDeposit = _proposalDeposit;
-        rewardAccount = new ManagedAccount(address(this));
-        DAOrewardAccount = new ManagedAccount(address(this));
+        rewardAccount = new ManagedAccount(address(this), false);
+        DAOrewardAccount = new ManagedAccount(address(this), false);
         if (address(rewardAccount) == 0)
             throw;
         if (address(DAOrewardAccount) == 0)
@@ -1740,7 +1747,7 @@ contract DAO_Creator {
     function createDAO(
         address _curator,
         uint _proposalDeposit,
-        uint _minValue,
+        uint _minTokensToCreate,
         uint _closingTime
     ) returns (DAO _newDAO) {
 
@@ -1748,7 +1755,7 @@ contract DAO_Creator {
             _curator,
             DAO_Creator(this),
             _proposalDeposit,
-            _minValue,
+            _minTokensToCreate,
             _closingTime,
             msg.sender
         );

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ For the full array of arguments available run `test.py --help`
 ```
 usage: test.py [-h] [--solc SOLC] [--geth GETH] [--keep-limits]
                [--clean-chain] [--verbose] [--closing-time CLOSING_TIME]
-               [--min-value MIN_VALUE] [--scenario {none,deploy,fund}]
+               [--scenario {none,deploy,fund}]
 
 DAO contracts test framework
 
@@ -24,8 +24,6 @@ optional arguments:
   --closing-time CLOSING_TIME
                         Number of minutes from now when the newly created DAO
                         creation ends
-  --min-value MIN_VALUE
-                        Minimum value to consider the DAO crowdfunded
   --scenario {none,deploy,fund}
                         Test scenario to play out
 ```

--- a/tests/scenarios/deploy/arguments.json
+++ b/tests/scenarios/deploy/arguments.json
@@ -4,9 +4,9 @@
     "description":"Number of seconds from now when the newly created DAO creation ends",
     "type":"int"
 }, {
-    "name": "min_value",
+    "name": "min_tokens_to_create",
     "default": 40,
-    "description": "Minimum value in Ether to consider the DAO fueled",
+    "description": "Minimum value in tokens for the DAO to create in order to be considered fueled",
     "type": "int"
 },{
     "name": "onetime_costs",

--- a/tests/scenarios/deploy/run.py
+++ b/tests/scenarios/deploy/run.py
@@ -26,7 +26,7 @@ def run(ctx):
             "offer_bin": ctx.offer_bin,
             "offer_onetime": ctx.args.deploy_onetime_costs,
             "offer_total": ctx.args.deploy_total_costs,
-            "min_value": ctx.args.deploy_min_value,
+            "min_tokens_to_create": ctx.args.deploy_min_tokens_to_create,
             "default_proposal_deposit": ctx.args.deploy_proposal_deposit
         },
         cb_before_creation=calculate_closing_time
@@ -54,3 +54,10 @@ def run(ctx):
             "offer_addr": ctx.offer_addr,
             "closing_time": ctx.closing_time
         }))
+
+    # after deployment recalculate for the subsequent tests what the min
+    # amount of tokens is in the case of extrabalance tests
+    if ctx.args.scenario == "extrabalance":
+        ctx.args.deploy_min_tokens_to_create = (
+            int(ctx.args.deploy_min_tokens_to_create * 1.5)
+        )

--- a/tests/scenarios/deploy/template.js
+++ b/tests/scenarios/deploy/template.js
@@ -17,7 +17,7 @@ var _daoCreatorContract = creatorContract.new(
 	        _curator,
 	        contract.address,
             $default_proposal_deposit,
-	        web3.toWei($min_value, "ether"),
+	        web3.toWei($min_tokens_to_create, "ether"),
 	        $closing_time,
             0,
 		    {

--- a/tests/scenarios/fuel/run.py
+++ b/tests/scenarios/fuel/run.py
@@ -13,7 +13,9 @@ def run(ctx):
     ctx.assert_scenario_ran('deploy')
 
     creation_secs = ctx.remaining_time()
-    ctx.total_supply = ctx.args.deploy_min_value + random.randint(1, 100)
+    ctx.total_supply = (
+        ctx.args.deploy_min_tokens_to_create + random.randint(1, 100)
+    )
     ctx.token_amounts = constrained_sum_sample_pos(
         len(ctx.accounts), ctx.total_supply
     )

--- a/tests/scenarios/fuel_fail2/run.py
+++ b/tests/scenarios/fuel_fail2/run.py
@@ -14,12 +14,12 @@ def run(ctx):
     ctx.assert_scenario_ran('deploy')
 
     accounts_num = len(ctx.accounts)
-    if accounts_num * 2 >= ctx.args.deploy_min_value - 4:
+    if accounts_num * 2 >= ctx.args.deploy_min_tokens_to_create - 4:
         print("Please increase the minimum fueling goal for the scenario.")
         sys.exit(1)
 
     creation_secs = ctx.remaining_time()
-    total_supply = ctx.args.deploy_min_value - 4
+    total_supply = ctx.args.deploy_min_tokens_to_create - 4
     proxy_amounts = constrained_sum_sample_pos(
         accounts_num, total_supply / 2
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -449,8 +449,6 @@ def calculate_bytecode(function_name, *args):
 
     bytecode = function_hash
     for arg in args:
-        # import pdb
-        # pdb.set_trace()
         arg_type = arg[0]
         arg_val = arg[1]
         if arg_type == "bool" or arg_type == "uint256":


### PR DESCRIPTION
`minValue` was introduced as the value in ether the DAO needs to accumulate
in order to be considered fueled. With the extra balance also taking in
ether and not counting towards the `totalSupply` this is inaccurate.

For this reason we rewrite the `minValue` as `minTokensToCreate` and
interpret it as the minimum amount of wei-equivalent tokens that the DAO
needs to create in order to be considered fueled.

There is also a fix for the extra balance fueling test which was failing
1 in 3 times exactly because the `minValue` goal was denominated in wei
and had not realized the `extraBalance` balance does not count towards
that goal

*WARNING* Mutually exclusive with #115 . Merge one or the other.