### PR TITLE
Close all types of overdue proposals at executeProposal

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -37,9 +37,9 @@ contract DAOInterface {
     uint constant splitExecutionPeriod = 27 days;
     // Period of time after which the minimum Quorum is halved
     uint constant quorumHalvingPeriod = 52 weeks;
-    // Period after which a proposal can be closed
+    // Period after which a proposal is closed
     // (used in the case `executeProposal` fails because it throws)
-    uint constant executeProposalPeriod = 5 days;
+    uint constant executeProposalPeriod = 10 days;
     // Denotes the maximum proposal deposit that can be given. It is given as
     // a fraction of total Ether spent plus balance of the DAO
     uint constant maxDepositDivisor = 100;
@@ -510,7 +510,7 @@ contract DAO is DAOInterface, Token, TokenCreation {
             ? splitExecutionPeriod
             : executeProposalPeriod;
         // If we are over deadline and waiting period, assert proposal is closed
-        if (now > p.votingDeadline + waitPeriod) {
+        if (p.open && now > p.votingDeadline + waitPeriod) {
             closeProposal(_proposalID);
             return;
         }

--- a/DAO.sol
+++ b/DAO.sol
@@ -237,12 +237,6 @@ contract DAOInterface {
         bytes _transactionData
     ) returns (bool _success);
 
-    /// @notice close the proposal (used in the case `executeProposal`
-    /// fails because it throws)
-    /// @param _proposalID The proposal ID
-    function emergenyCloseProposal(uint _proposalID) external;
-
-
     /// @notice ATTENTION! I confirm to move my remaining ether to a new DAO
     /// with `_newCurator` as the new Curator, as has been
     /// proposed in proposal `_proposalID`. This will burn my tokens. This can
@@ -512,10 +506,12 @@ contract DAO is DAOInterface, Token, TokenCreation {
 
         Proposal p = proposals[_proposalID];
 
-        if (p.newCurator) {
-            if (now > p.votingDeadline + splitExecutionPeriod) {
-                p.open = false;
-            }
+        uint waitPeriod = p.newCurator
+            ? splitExecutionPeriod
+            : executeProposalPeriod;
+        // If we are over deadline and waiting period, assert proposal is closed
+        if (now > p.votingDeadline + waitPeriod) {
+            closeProposal(_proposalID);
             return;
         }
 
@@ -585,12 +581,6 @@ contract DAO is DAOInterface, Token, TokenCreation {
         if (p.open)
             sumOfProposalDeposits -= p.proposalDeposit;
         p.open = false;
-    }
-
-    function emergenyCloseProposal(uint _proposalID) external {
-        Proposal p = proposals[_proposalID];
-        if (p.votingDeadline + executeProposalPeriod < now && p.open)
-            closeProposal(_proposalID);
     }
 
     function splitDAO(

--- a/paper/Paper.tex
+++ b/paper/Paper.tex
@@ -498,8 +498,6 @@ The arguments of the function are:
 The function checks whether the voting deadline has passed and that the \verb|transactionData| matches the proposal ID. Then it checks whether the quorum has been met (see Eq. \ref{minQuorum}) and if the proposal had a majority of support. If this is the case, it executes the proposal and refunds the 
 proposal deposit. If the quorum has been achieved, but the proposal was declined by the majority of the voters, the proposal deposit is refunded and the proposal closes.
 
-\subsubsection*{emergenyCloseProposal}
-This is used in the case `executeProposal` fails because it throws (e.g. when returuning the deposit, because the fallback function of this address throws, or when executing the proposed transaction). It can be called $5$ days after the voting deadline of the proposal passed. It will close the proposal.
 \subsubsection*{splitDAO}
 After a new Curator has been proposed, and the debating period in which the token holders could vote for or against the proposal has passed, this function is called by each of the DAO token holders that want to leave the current DAO and move to a new DAO with the proposed new Curator. This function creates a new DAO and moves a portion of the ether, as well as a portion of the reward tokens to the new DAO.
 The arguments are:
@@ -914,9 +912,9 @@ contract DAOInterface {
     uint constant splitExecutionPeriod = 27 days;
     // Period of time after which the minimum Quorum is halved
     uint constant quorumHalvingPeriod = 52 weeks;
-    // Period after which a proposal can be closed
+    // Period after which a proposal is closed
     // (used in the case `executeProposal` fails because it throws)
-    uint constant executeProposalPeriod = 5 days;
+    uint constant executeProposalPeriod = 10 days;
     // Denotes the maximum proposal deposit that can be given. It is given as
     // a fraction of total Ether spent plus balance of the DAO
     uint constant maxDepositDivisor = 100;
@@ -1113,12 +1111,6 @@ contract DAOInterface {
         uint _proposalID,
         bytes _transactionData
     ) returns (bool _success);
-
-    /// @notice close the proposal (used in the case `executeProposal`
-    /// fails because it throws)
-    /// @param _proposalID The proposal ID
-    function emergenyCloseProposal(uint _proposalID) external;
-
 
     /// @notice ATTENTION! I confirm to move my remaining ether to a new DAO
     /// with `_newCurator` as the new Curator, as has been
@@ -1389,10 +1381,12 @@ contract DAO is DAOInterface, Token, TokenCreation {
 
         Proposal p = proposals[_proposalID];
 
-        if (p.newCurator) {
-            if (now > p.votingDeadline + splitExecutionPeriod) {
-                p.open = false;
-            }
+        uint waitPeriod = p.newCurator
+            ? splitExecutionPeriod
+            : executeProposalPeriod;
+        // If we are over deadline and waiting period, assert proposal is closed
+        if (p.open && now > p.votingDeadline + waitPeriod) {
+            closeProposal(_proposalID);
             return;
         }
 
@@ -1462,12 +1456,6 @@ contract DAO is DAOInterface, Token, TokenCreation {
         if (p.open)
             sumOfProposalDeposits -= p.proposalDeposit;
         p.open = false;
-    }
-
-    function emergenyCloseProposal(uint _proposalID) external {
-        Proposal p = proposals[_proposalID];
-        if (p.votingDeadline + executeProposalPeriod < now && p.open)
-            closeProposal(_proposalID);
     }
 
     function splitDAO(


### PR DESCRIPTION
- Close all types or proposals at `executeProposal()` if their voting
  deadline plus waiting period has expired.

- Remove the now no longer needed `emergenyCloseProposal()`