### PR TITLE
Force contractor to promise open source

### DIFF
--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -39,6 +39,7 @@ contract SampleOffer {
     DAO client; // address of DAO
 
     bool public promiseValid;
+    bool public isOpenSource;
     uint public rewardDivisor;
     uint public deploymentReward;
 
@@ -54,6 +55,12 @@ contract SampleOffer {
 
     modifier onlyClient {
         if (msg.sender != address(client))
+            throw;
+        _
+    }
+
+    modifier onlyContractor {
+        if (msg.sender != contractor)
             throw;
         _
     }
@@ -77,14 +84,20 @@ contract SampleOffer {
         deploymentReward = _deploymentReward;
     }
 
-    function sign() {
+    function sign(bool expectsOpenSource) {
         if (msg.value < totalCosts || dateOfSignature != 0)
             throw;
         if (!contractor.send(oneTimeCosts))
             throw;
+        if (expectsOpenSource && !isOpenSource)
+            throw;
         client = DAO(msg.sender);
         dateOfSignature = now;
         promiseValid = true;
+    }
+    
+    function promiseOpenSource() onlyContractor {
+        isOpenSource = true;
     }
 
     function setDailyCosts(uint _dailyCosts) onlyClient {


### PR DESCRIPTION
An attempt to make explicit two things: (1) a promise from the contractor that the project developed under this proposal will be open source, and (2) an expectation (or a lack of an expectation) from the DAO that the materials will be open source.

Note that if the DAO sends 'false' to the sign function, they are saying to do not expect open source (but will accept it if offered). If the DAO sends 'true,' then the contract sill be signed only if the contractor has already promised to develop open source.

Forcing the contractor to develop open source (at the DAO's discretion) is important to insure that the product that is ultimately developed is exactly what the DAO is paying for. Trust but verify.