### PR TITLE
SampleOffer should not accept overpayment

### DIFF
--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -63,7 +63,7 @@ contract SampleOffer {
     }
 
     function sign() {
-        if (msg.value < totalCosts || dateOfSignature != 0)
+        if (msg.value != totalCosts || dateOfSignature != 0)
             throw;
         if (!contractor.send(oneTimeCosts))
             throw;


### PR DESCRIPTION
Signing the offer with more money than the `totalCosts` is possible. This PR addresses that.