### PR TITLE
SampleOffer: Specify client at constructor

### DIFF
--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -49,12 +49,14 @@ contract SampleOffer {
 
     function SampleOffer(
         address _contractor,
+        address _client,
         bytes32 _IPFSHashOfTheProposalDocument,
         uint _totalCosts,
         uint _oneTimeCosts,
         uint _minDailyWithdrawLimit
     ) {
         contractor = _contractor;
+        client = DAO(_client);
         IPFSHashOfTheProposalDocument = _IPFSHashOfTheProposalDocument;
         totalCosts = _totalCosts;
         oneTimeCosts = _oneTimeCosts;
@@ -67,7 +69,6 @@ contract SampleOffer {
             throw;
         if (!contractor.send(oneTimeCosts))
             throw;
-        client = DAO(msg.sender);
         dateOfSignature = now;
         isContractValid = true;
     }

--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -65,7 +65,9 @@ contract SampleOffer {
     }
 
     function sign() {
-        if (msg.value != totalCosts || dateOfSignature != 0)
+        if (msg.sender != address(client) // no good samaritans give us money
+            || msg.value != totalCosts    // no under/over payment
+            || dateOfSignature != 0)      // don't sign twice
             throw;
         if (!contractor.send(oneTimeCosts))
             throw;

--- a/deploy/deployOffer.js
+++ b/deploy/deployOffer.js
@@ -7,6 +7,7 @@ var offerContract = web3.eth.contract(offer_abi);
 
 var _offerrContract = offerContract.new(
     contractor,
+    offer_client_dao_address,
     "0x0",
     offer_total_costs,
     offer_onetime_costs,

--- a/deploy/prepare.py
+++ b/deploy/prepare.py
@@ -137,6 +137,11 @@ if __name__ == "__main__":
         default=1,
         help='Minimum daily withrdawal limit'
     )
+    p.add_argument(
+        '--offer-client-dao-address',
+        default="0x159fe90ac850c895e4fd144e705923cfa042d974",  # A testnet DAO
+        help='The address of the DAO to set as the client of the SampleOffer'
+    )
     args = p.parse_args()
     ctx = TestDeployContext(args)
     comp = ctx.compile_contract("DAO.sol")
@@ -173,6 +178,9 @@ if __name__ == "__main__":
         ))
         f.write("offer_min_daily_withdraw = {};\n".format(
             to_wei(args.offer_min_daily_withdraw)
+        ))
+        f.write("offer_client_dao_address = '{}';\n".format(
+            args.offer_client_dao_address
         ))
 
     ctx.cleanup()

--- a/tests/scenarios/deploy/template.js
+++ b/tests/scenarios/deploy/template.js
@@ -29,37 +29,34 @@ var _daoCreatorContract = creatorContract.new(
 		        console.log("At DAO creation callback");
 		        if (typeof contract.address != 'undefined') {
                     addToTest('dao_address', contract.address);
+
+                    // and finally now deploy the Sample Offer
+                    var offerContract = web3.eth.contract($offer_abi);
+                    var offer = offerContract.new(
+                        contractor,
+                        contract.address, // client DAO address
+                        '0x0',  // This is a hash of the paper contract. Does not matter for testing
+                        web3.toWei($offer_total, "ether"), //total costs
+                        web3.toWei($offer_onetime, "ether"), //one time costs
+                        web3.toWei(1, "ether"), //min daily costs
+                        {
+	                        from: contractor,
+	                        data: '$offer_bin',
+	                        gas: 3000000
+                        }, function (e, offer_contract) {
+	                        if (e) {
+                                console.log(e + " at Offer Contract creation!");
+	                        } else if (typeof offer_contract.address != 'undefined') {
+                                addToTest('offer_address', offer_contract.address);
+                                testResults();
+                            }
+                        }
+                    );
+                    checkWork();
 		        }
 		    });
         checkWork();
 	}
     });
 checkWork();
-var offerContract = web3.eth.contract($offer_abi);
-var offer = offerContract.new(
-    contractor,
-    '0x0',  // This is a hash of the paper contract. Does not matter for testing
-    web3.toWei($offer_total, "ether"), //total costs
-    web3.toWei($offer_onetime, "ether"), //one time costs
-    web3.toWei(1, "ether"), //min daily costs
-    {
-	    from: contractor,
-	    data: '$offer_bin',
-	    gas: 3000000
-    }, function (e, contract) {
-	    if (e) {
-            console.log(e + " at Offer Contract creation!");
-	    } else if (typeof contract.address != 'undefined') {
-            addToTest('offer_address', contract.address);
-        }
-    }
-);
-checkWork();
-console.log("mining contract, please wait");
-miner.start(1);
-setTimeout(function() {
-    miner.stop();
-    testResults();
-}, 3000);
-
 


### PR DESCRIPTION
- SampleOffer now requires you to specify the client from the very beginning instead of assuming it's the first person who calls `sign()` and pays the initial costs.

- `sign()` can now only be called by the client. Effectively this stops random people from giving us money and forcing us to re-deploy the offer :)

- Adjusted tests, and deployment scripts to function properly with the changes this PR introduces.