### PR TITLE
DTH Pool implementation and tests

### DIFF
--- a/DTHPool.sol
+++ b/DTHPool.sol
@@ -1,0 +1,320 @@
+/*
+This file is part of the DAO.
+
+The DAO is free software: you can redistribute it and/or modify
+it under the terms of the GNU lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The DAO is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU lesser General Public License for more details.
+
+You should have received a copy of the GNU lesser General Public License
+along with the DAO.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import "./libs/oraclize.sol";
+import "./Token.sol";
+
+/////////////////////
+// There is a solidity bug in the return parameters that it's not solved
+// when the bug is solved, the import from DAO is more clean.
+// In the meantime, a workaround proxy is defined
+
+// Uncoment this line when error fixed
+// import "./DAO.sol";
+
+// Workaround proxy remove when fixed
+contract DAO {
+    function proposals(uint _proposalID) returns(
+        address recipient,
+        uint amount,
+        uint descriptionIdx,
+        uint votingDeadline,
+        bool open,
+        bool proposalPassed,
+        bytes32 proposalHash,
+        uint proposalDeposit,
+        bool newCurator
+    );
+
+    function transfer(address _to, uint256 _amount) returns (bool success);
+
+    function transferFrom(address _from, address _to, uint256 _amount) returns (bool success);
+
+    function vote(
+        uint _proposalID,
+        bool _supportsProposal
+    ) returns (uint _voteID);
+
+    function balanceOf(address _owner) constant returns (uint256 balance);
+}
+// End of workaround proxy
+////////////////////
+
+
+contract DTHPoolInterface {
+
+    // delegae url
+    string public delegateUrl;
+
+    // Max time the tokens can be blocked.
+    // The real voting in the DAO will be called in the last moment in order
+    // to block the tokens for the minimum time. This parameter defines the
+    // seconds before the voting period ends that the vote can be performed
+    uint maxTimeBlocked;
+
+
+    // Address of the delegate
+    address public delegate;
+
+    // The DAO contract
+    address public daoAddress;
+
+    struct ProposalStatus {
+
+        // True when the delegate sets the vote
+        bool voteSet;
+
+        // True if the proposal should ve voted
+        bool willVote;
+
+        // True if the proposal should be accepted.
+        bool suportProposal;
+
+        // True when the vote is performed;
+        bool executed;
+
+        // Proposal votingDeadline
+        uint votingDeadline;
+
+        // String set by the delegator with the motivation
+        string motivation;
+    }
+
+    // Statuses of the diferent proposal
+    mapping (uint => ProposalStatus) public proposalStatuses;
+
+
+    // Index of proposals by oraclizeId
+    mapping (bytes32 => uint) public oraclizeId2proposalId;
+
+    /// @dev Constructor setting the dao address and the delegate
+    /// @param _daoAddress address of the DAO
+    /// @param _delegate adddress of the delegate.
+    /// @param _maxTimeBlocked the maximum time the tokens will be blocked
+    /// @param _delegateName Name of the delegate
+    /// @param _delegateUrl Url of the delegate
+    /// @param _tokenSymbol token  symbol.
+    // DTHPool(address _daoAddress, address _delegate, uint _maxTimeBlocked, string _delegateName, string _delegateUrl, string _tokenSymbol);
+
+
+    /// @notice send votes to this contract.
+    /// @param _amount Tokens that will be transfered to the pool.
+    /// @return Whether the transfer was successful or not
+    function delegateDAOTokens(uint _amount) returns (bool _success);
+
+    /// Returns DAO tokens to the original
+    /// @param _amount that will be transfered back to the owner.
+    /// @return Whether the transfer was successful or not
+    function undelegateDAOTokens(uint _amount) returns (bool _success);
+
+
+    /// @notice This method will be called by the delegate to publish what will
+    /// be his vote in a specific proposal.
+    /// @param _proposalID The proposal to set the vote.
+    /// @param _willVote true If the proposal will be voted.
+    /// @param _supportsProposal What will be the vote.
+    function setVoteIntention(
+        uint _proposalID,
+        bool _willVote,
+        bool _supportsProposal,
+        string _motivation
+    ) returns (bool _success);
+
+    /// @notice This method will be doing the actual voting in the DAO
+    /// for the _proposalID
+    /// @param _proposalID The proposal to set the vote.
+    /// @return _finalized true if this vote Proposal must not be executed again.
+    function executeVote(uint _proposalID) returns (bool _finalized);
+
+
+    /// @notice This function is intended because if some body sends tokens
+    /// directly to this contract, the tokens can be sent to the delegate
+    function fixTokens() returns (bool _success);
+
+
+    /// @notice If some body sends ether to this contract, the delegate will be
+    /// able to extract it.
+    function getEther() returns (uint _amount);
+
+    /// @notice Called when some body delegates token to the pool
+    event Delegate(address indexed _from, uint256 _amount);
+
+    /// @notice Called when some body undelegates token to the pool
+    event Undelegate(address indexed _from, uint256 _amount);
+
+    /// @notice Called when the delegate set se vote intention
+    event VoteIntentionSet(uint indexed _proposalID, bool _willVote, bool _supportsProposal);
+
+    /// @notice Called when the vote is executed in the DAO
+    event VoteExecuted(uint indexed _proposalID);
+
+}
+
+contract DTHPool is DTHPoolInterface, Token, usingOraclize {
+
+    modifier onlyDelegate() {if (msg.sender != delegate) throw; _}
+
+    // DTHPool(address _daoAddress, address _delegate, uint _maxTimeBlocked, string _delegateName, string _delegateUrl, string _tokenSymbol);
+
+    function DTHPool(
+        address _daoAddress,
+        address _delegate,
+        uint _maxTimeBlocked,
+        string _delegateName,
+        string _delegateUrl,
+        string _tokenSymbol
+    ) {
+        daoAddress = _daoAddress;
+        delegate = _delegate;
+        delegateUrl = _delegateUrl;
+        maxTimeBlocked = _maxTimeBlocked;
+        name = _delegateName;
+        symbol = _tokenSymbol;
+        decimals = 16;
+        oraclize_setNetwork(networkID_auto);
+    }
+
+    function delegateDAOTokens(uint _amount) returns (bool _success) {
+        DAO dao = DAO(daoAddress);
+        if (!dao.transferFrom(msg.sender, address(this), _amount)) {
+            throw;
+        }
+
+        balances[msg.sender] += _amount;
+        totalSupply += _amount;
+        Delegate(msg.sender, _amount);
+        return true;
+    }
+
+    function undelegateDAOTokens(uint _amount) returns (bool _success) {
+        DAO dao = DAO(daoAddress);
+        if (_amount > balances[msg.sender]) {
+            throw;
+        }
+
+        if (!dao.transfer(msg.sender, _amount)) {
+            throw;
+        }
+
+        balances[msg.sender] -= _amount;
+        totalSupply -= _amount;
+        Undelegate(msg.sender, _amount);
+        return true;
+    }
+
+    function setVoteIntention(
+        uint _proposalID,
+        bool _willVote,
+        bool _supportsProposal,
+        string _motivation
+    ) onlyDelegate returns (bool _success) {
+        DAO dao = DAO(daoAddress);
+
+        ProposalStatus proposalStatus = proposalStatuses[_proposalID];
+
+        if (proposalStatus.voteSet) {
+            throw;
+        }
+
+        var (,,,votingDeadline, ,,,,newCurator) = dao.proposals(_proposalID);
+
+        if (votingDeadline < now || newCurator ) {
+            throw;
+        }
+
+        proposalStatus.voteSet = true;
+        proposalStatus.willVote = _willVote;
+        proposalStatus.suportProposal = _supportsProposal;
+        proposalStatus.votingDeadline = votingDeadline;
+        proposalStatus.motivation = _motivation;
+
+        VoteIntentionSet(_proposalID, _willVote, _supportsProposal);
+
+        if (!_willVote) {
+            proposalStatus.executed = true;
+            VoteExecuted(_proposalID);
+        }
+
+        bool finalized = executeVote(_proposalID);
+
+        if ((!finalized)&&(address(OAR) != 0)) {
+            bytes32 oraclizeId = oraclize_query(votingDeadline - maxTimeBlocked +15, "URL", "");
+
+            oraclizeId2proposalId[oraclizeId] = _proposalID;
+        }
+
+        return true;
+    }
+
+    function executeVote(uint _proposalID) returns (bool _finalized) {
+        DAO dao = DAO(daoAddress);
+        ProposalStatus proposalStatus = proposalStatuses[_proposalID];
+
+        if (!proposalStatus.voteSet
+            || now > proposalStatus.votingDeadline
+            || !proposalStatus.willVote
+            || proposalStatus.executed) {
+
+            return true;
+        }
+
+        if (now < proposalStatus.votingDeadline - maxTimeBlocked) {
+            return false;
+        }
+
+        dao.vote(_proposalID, proposalStatus.suportProposal);
+        proposalStatus.executed = true;
+        VoteExecuted(_proposalID);
+
+        return true;
+    }
+
+    function __callback(bytes32 oid, string result) {
+        uint proposalId = oraclizeId2proposalId[oid];
+        executeVote(proposalId);
+        oraclizeId2proposalId[oid] = 0;
+    }
+
+    function fixTokens() returns (bool _success) {
+        DAO dao = DAO(daoAddress);
+        uint ownedTokens = dao.balanceOf(this);
+        if (ownedTokens < totalSupply) {
+            throw;
+        }
+        uint fixTokens = ownedTokens - totalSupply;
+
+        if (fixTokens == 0) {
+            return true;
+        }
+
+        balances[delegate] += fixTokens;
+        totalSupply += fixTokens;
+
+        return true;
+    }
+
+    function getEther() onlyDelegate returns (uint _amount) {
+        uint amount = this.balance;
+
+        if (!delegate.call.value(amount)()) {
+            throw;
+        }
+
+        return amount;
+    }
+
+}

--- a/README_DTHPool.md
+++ b/README_DTHPool.md
@@ -1,0 +1,107 @@
+# DTHPool contract
+
+The DTHPool contract allows a DTH to lend their DAO Tokens to a delegate in order to vote in his name  without loosing the control of his DAO tokens.
+
+## Normal procedures
+
+### Delegate the votes.
+
+To delegate the votes the DTH needs to call this two functions in two separated transactions:
+
+    1. DAO.approve(DTHPoolAdress, [amount of Ð that you want to delegate])
+    2. DTHPool.delegateDAOTokens([amount Ð that you want to delegate])
+
+Once the delegation is finished, you will exchange normal DAO tokens ( Ð ) by the same
+number of delegate dao tokens ( dÐ ) .
+
+It is convenient that in mist you wathch both contracts and both tokens.
+
+### Undelegate the votes
+
+To undelegate the vote the DTH just call:
+
+    DTHPool.undelegateDAOTokens([amount Ð that you want to undelegate])
+
+The DTH will be able to undelegate and so restore his original DAO tokens at any time except in the last moments before the voting period of each proposal.
+
+### Voting mecanism
+
+When a new regular proposal is made to the DAO, the delegate can set his voting intention.
+
+    setVoteIntention(
+        uint _proposalID,
+        bool _willVote,
+        bool _supportsProposal,
+        string _motivation
+    )
+
+* **_proposalID**: the proposal that wants to set the position for.
+* **_willVote**: true if this contract will vote to this proposa.
+* **_supportsProposal**: true if it will vote to accept the proposal and false if it will not accept.
+* **_motivation** free text where the delegate can explain why he set this position.
+
+The delegate can not vote in split proposals.
+
+The vote will not effectivelly send the vote to the DAO until the last moment before the
+debatingPeriod closes.
+
+In the testing DTHPool this parameter is set to 2 minutes.
+
+The contract will make the vote automatically, no action is needed by the user.
+
+### Query the delegate positions.
+
+Users can query the delegate position of any proposal by calling:
+
+    DTHPool.proposalStatuses(proposalId)
+
+
+## Test and practice
+
+In order to test and practice with DTHPool contract, I just deployed a test DAO contract and DTHPool contract in the test net.
+
+* DAO address: 0x0b1aef3ea19bd816e689b7a2a373459170bd8e6e
+* DTHPool address: 0x840b7ac7deb5b7441921568a3baa3572e638fecd
+
+Fill free to contact me ( @jbaylina ) or any member in the #art_of_the_dao channel in thedao.slack.com
+
+You can get an free invitation here: http://slack.slock.it:3000/
+
+There you can get testDAOs, testEther, support and love ;)
+
+## Q&A
+
+Q: What happen if some body sends the DAO tokens directly to the contract?
+
+A: The delegate can call the fixTokens() to assign those tokens to him. If
+the delegate is a nice guy, he can return them back to the clumsy DTH.
+
+---
+Q: I want to be a delegate. How can I deploy my own contract?
+
+A: You just deplot the DTHPool with the following parameters in the constructor:
+
+* _daoAddress : The Address of the DAO 0xbb9bc244d798123fde783fcc1c72d3bb8c189413 in case of TheDAO
+* _delegate : Your own address (The delegate)
+* _maxTimeBlocked : Time in seconds before the debate closing time when the vote will be triggered automatically.
+* _delegateName : Your name (optional string)
+* _delegateUrl : A URL for more information about yourself (optional string)
+* _tokenSymbol : Symbol for your delegate tokens. Example jbÐ
+
+**IMPORTANT:** The automatic call is done via Oraclize service, so it is important that during the construct or in another transaction after the construction you send some ether to this contract.
+
+---
+Q: Can a delegate change his vote intention?
+
+A: NO. He can change and comunicate any thing befor he set his intention. But once there it cannot be changed.
+
+---
+Q: How can a user vote different that his delegate?
+
+A: He can undelegate his tokens, vote directly to the DAO and then, after the voting period for that proposal change, he can delegate back hist tokens.
+
+---
+Q: Can de delegate tokens be transfered?
+
+A: Yes, like any other token.
+

--- a/libs/oraclize.sol
+++ b/libs/oraclize.sol
@@ -1,0 +1,264 @@
+// <ORACLIZE_API>
+/*
+Copyright (c) 2015-2016 Oraclize srl, Thomas Bertani
+
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+contract OraclizeI {
+    address public cbAddress;
+    function query(uint _timestamp, string _datasource, string _arg) returns (bytes32 _id);
+    function query_withGasLimit(uint _timestamp, string _datasource, string _arg, uint _gaslimit) returns (bytes32 _id);
+    function query2(uint _timestamp, string _datasource, string _arg1, string _arg2) returns (bytes32 _id);
+    function query2_withGasLimit(uint _timestamp, string _datasource, string _arg1, string _arg2, uint _gaslimit) returns (bytes32 _id);
+    function getPrice(string _datasource) returns (uint _dsprice);
+    function getPrice(string _datasource, uint gaslimit) returns (uint _dsprice);
+    function useCoupon(string _coupon);
+    function setProofType(byte _proofType);
+}
+contract OraclizeAddrResolverI {
+    function getAddress() returns (address _addr);
+}
+contract usingOraclize {
+    uint constant day = 60*60*24;
+    uint constant week = 60*60*24*7;
+    uint constant month = 60*60*24*30;
+    byte constant proofType_NONE = 0x00;
+    byte constant proofType_TLSNotary = 0x10;
+    byte constant proofStorage_IPFS = 0x01;
+    uint8 constant networkID_auto = 0;
+    uint8 constant networkID_mainnet = 1;
+    uint8 constant networkID_testnet = 2;
+    uint8 constant networkID_morden = 2;
+    uint8 constant networkID_consensys = 161;
+
+    OraclizeAddrResolverI OAR;
+
+    OraclizeI oraclize;
+    modifier oraclizeAPI {
+        address oraclizeAddr = OAR.getAddress();
+        if (oraclizeAddr == 0){
+            oraclize_setNetwork(networkID_auto);
+            oraclizeAddr = OAR.getAddress();
+        }
+        oraclize = OraclizeI(oraclizeAddr);
+        _
+    }
+    modifier coupon(string code){
+        oraclize = OraclizeI(OAR.getAddress());
+        oraclize.useCoupon(code);
+        _
+    }
+
+    function oraclize_setNetwork(uint8 networkID) internal returns(bool){
+        if (getCodeSize(0x1d3b2638a7cc9f2cb3d298a3da7a90b67e5506ed)>0){
+            OAR = OraclizeAddrResolverI(0x1d3b2638a7cc9f2cb3d298a3da7a90b67e5506ed);
+            return true;
+        }
+        if (getCodeSize(0x9efbea6358bed926b293d2ce63a730d6d98d43dd)>0){
+            OAR = OraclizeAddrResolverI(0x9efbea6358bed926b293d2ce63a730d6d98d43dd);
+            return true;
+        }
+        if (getCodeSize(0x20e12a1f859b3feae5fb2a0a32c18f5a65555bbf)>0){
+            OAR = OraclizeAddrResolverI(0x20e12a1f859b3feae5fb2a0a32c18f5a65555bbf);
+            return true;
+        }
+        return false;
+    }
+
+    function oraclize_query(string datasource, string arg) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query.value(price)(0, datasource, arg);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query.value(price)(timestamp, datasource, arg);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query_withGasLimit.value(price)(timestamp, datasource, arg, gaslimit);
+    }
+    function oraclize_query(string datasource, string arg, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query_withGasLimit.value(price)(0, datasource, arg, gaslimit);
+    }
+    function oraclize_query(string datasource, string arg1, string arg2) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query2.value(price)(0, datasource, arg1, arg2);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg1, string arg2) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query2.value(price)(timestamp, datasource, arg1, arg2);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg1, string arg2, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query2_withGasLimit.value(price)(timestamp, datasource, arg1, arg2, gaslimit);
+    }
+    function oraclize_query(string datasource, string arg1, string arg2, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query2_withGasLimit.value(price)(0, datasource, arg1, arg2, gaslimit);
+    }
+    function oraclize_cbAddress() oraclizeAPI internal returns (address){
+        return oraclize.cbAddress();
+    }
+    function oraclize_setProof(byte proofP) oraclizeAPI internal {
+        return oraclize.setProofType(proofP);
+    }
+
+    function getCodeSize(address _addr) constant internal returns(uint _size) {
+        assembly {
+            _size := extcodesize(_addr)
+        }
+    }
+
+
+    function parseAddr(string _a) internal returns (address){
+        bytes memory tmp = bytes(_a);
+        uint160 iaddr = 0;
+        uint160 b1;
+        uint160 b2;
+        for (uint i=2; i<2+2*20; i+=2){
+            iaddr *= 256;
+            b1 = uint160(tmp[i]);
+            b2 = uint160(tmp[i+1]);
+            if ((b1 >= 97)&&(b1 <= 102)) b1 -= 87;
+            else if ((b1 >= 48)&&(b1 <= 57)) b1 -= 48;
+            if ((b2 >= 97)&&(b2 <= 102)) b2 -= 87;
+            else if ((b2 >= 48)&&(b2 <= 57)) b2 -= 48;
+            iaddr += (b1*16+b2);
+        }
+        return address(iaddr);
+    }
+
+
+    function strCompare(string _a, string _b) internal returns (int) {
+        bytes memory a = bytes(_a);
+        bytes memory b = bytes(_b);
+        uint minLength = a.length;
+        if (b.length < minLength) minLength = b.length;
+        for (uint i = 0; i < minLength; i ++)
+            if (a[i] < b[i])
+                return -1;
+            else if (a[i] > b[i])
+                return 1;
+        if (a.length < b.length)
+            return -1;
+        else if (a.length > b.length)
+            return 1;
+        else
+            return 0;
+   }
+
+    function indexOf(string _haystack, string _needle) internal returns (int)
+    {
+        bytes memory h = bytes(_haystack);
+        bytes memory n = bytes(_needle);
+        if(h.length < 1 || n.length < 1 || (n.length > h.length))
+            return -1;
+        else if(h.length > (2**128 -1))
+            return -1;
+        else
+        {
+            uint subindex = 0;
+            for (uint i = 0; i < h.length; i ++)
+            {
+                if (h[i] == n[0])
+                {
+                    subindex = 1;
+                    while(subindex < n.length && (i + subindex) < h.length && h[i + subindex] == n[subindex])
+                    {
+                        subindex++;
+                    }
+                    if(subindex == n.length)
+                        return int(i);
+                }
+            }
+            return -1;
+        }
+    }
+
+    function strConcat(string _a, string _b, string _c, string _d, string _e) internal returns (string){
+        bytes memory _ba = bytes(_a);
+        bytes memory _bb = bytes(_b);
+        bytes memory _bc = bytes(_c);
+        bytes memory _bd = bytes(_d);
+        bytes memory _be = bytes(_e);
+        string memory abcde = new string(_ba.length + _bb.length + _bc.length + _bd.length + _be.length);
+        bytes memory babcde = bytes(abcde);
+        uint k = 0;
+        for (uint i = 0; i < _ba.length; i++) babcde[k++] = _ba[i];
+        for (i = 0; i < _bb.length; i++) babcde[k++] = _bb[i];
+        for (i = 0; i < _bc.length; i++) babcde[k++] = _bc[i];
+        for (i = 0; i < _bd.length; i++) babcde[k++] = _bd[i];
+        for (i = 0; i < _be.length; i++) babcde[k++] = _be[i];
+        return string(babcde);
+    }
+
+    function strConcat(string _a, string _b, string _c, string _d) internal returns (string) {
+        return strConcat(_a, _b, _c, _d, "");
+    }
+
+    function strConcat(string _a, string _b, string _c) internal returns (string) {
+        return strConcat(_a, _b, _c, "", "");
+    }
+
+    function strConcat(string _a, string _b) internal returns (string) {
+        return strConcat(_a, _b, "", "", "");
+    }
+
+    // parseInt
+    function parseInt(string _a) internal returns (uint) {
+        return parseInt(_a, 0);
+    }
+
+    // parseInt(parseFloat*10^_b)
+    function parseInt(string _a, uint _b) internal returns (uint) {
+        bytes memory bresult = bytes(_a);
+        uint mint = 0;
+        bool decimals = false;
+        for (uint i=0; i<bresult.length; i++){
+            if ((bresult[i] >= 48)&&(bresult[i] <= 57)){
+                if (decimals){
+                   if (_b == 0) break;
+                    else _b--;
+                }
+                mint *= 10;
+                mint += uint(bresult[i]) - 48;
+            } else if (bresult[i] == 46) decimals = true;
+        }
+        return mint;
+    }
+
+
+}
+// </ORACLIZE_API>


### PR DESCRIPTION
This pull request implements a DTH Pool contract in the userland space.

* This contract allows for a DTH to delegate tokens to a pool. 
* This pool is controlled by a delegate. (It can be a multisig).
* This contract works with DAO 1.0
* This contract can be used also cold storage tokens voting.

The normal prcess of the contract is:

1. dao.approve   -> The user approves to transfer tokens to dthpool contract.
2. dthpool.delegateDAOTokens -> The usr transfer tokens to the delegate
3. dthpool.setVoteIntention -> The delegate set the intention of the vote as soon as he can.
4. dthpool.undelegateDAOTokens -> Users can undelegate the tokens if they don't agree and vote for themseves. If they agree, they just do nothing.
5. dthpool.executeVote -> The dalegate, a timer or any body calls this function just before the votin ends to actualy do the real vote in the DAO.

Thank you to @psdev, @colm, @LefterisJP  and @hiromant for the idea and the discussion in thedao slack.
