### PR TITLE
DAOreward payment fixed

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -697,7 +697,7 @@ contract DAO is DAOInterface, Token, TokenCreation {
             (rewardToken[msg.sender] * DAOrewardAccount.accumulatedInput()) /
             totalRewardToken - DAOpaidOut[msg.sender];
 
-        if ( DAOrewardAccount.balance < reward) reward = DAOrewardAccount.balance;
+        reward = DAOrewardAccount.balance < reward ? DAOrewardAccount.balance : reward;
 
         if(_toMembers) {
             if (!DAOrewardAccount.payOut(dao.rewardAccount(), reward))
@@ -723,7 +723,7 @@ contract DAO is DAOInterface, Token, TokenCreation {
         uint reward =
             (balanceOf(_account) * rewardAccount.accumulatedInput()) / totalSupply - paidOut[_account];
 
-        if ( rewardAccount.balance < reward) reward = rewardAccount.balance;
+        reward = rewardAccount.balance < reward ? rewardAccount.balance : reward;
 
         if (!rewardAccount.payOut(_account, reward))
             throw;

--- a/DAO.sol
+++ b/DAO.sol
@@ -696,6 +696,9 @@ contract DAO is DAOInterface, Token, TokenCreation {
         uint reward =
             (rewardToken[msg.sender] * DAOrewardAccount.accumulatedInput()) /
             totalRewardToken - DAOpaidOut[msg.sender];
+
+        if ( DAOrewardAccount.balance < reward) reward = DAOrewardAccount.balance;
+
         if(_toMembers) {
             if (!DAOrewardAccount.payOut(dao.rewardAccount(), reward))
                 throw;
@@ -719,6 +722,9 @@ contract DAO is DAOInterface, Token, TokenCreation {
 
         uint reward =
             (balanceOf(_account) * rewardAccount.accumulatedInput()) / totalSupply - paidOut[_account];
+
+        if ( rewardAccount.balance < reward) reward = rewardAccount.balance;
+
         if (!rewardAccount.payOut(_account, reward))
             throw;
         paidOut[_account] += reward;


### PR DESCRIPTION
Imagine the next situation:

Initial stete:
 * Main DAO have 90 RewardTokens
 * A splited DAO has 10 RewardTokens.

STEP 1: 100E are sent to the DAORewardToken.Main and SLIPT DAO collect it.

So the state is:
* DAOrewardAccount.accumulatedInput() = 100
* DAOpaidOut[main] = 90
* DAOpaidOut[SlitDAO] = 10
* DAOrewardAccount.balance = 0

STEP 2: A new investment is done of 100E 

 * Main DAO have 190 RewardTokens
 * A splited DAO has 10 Reward Tokens.

STEP 3: 10E Is added to the DAO rewardAccount

* DAOrewardAccount.accumulatedInput() = 110
* DAOrewardAccount.balance = 10

If now the main DAO want's to get his rerard he can't because:

        uint reward =
            (rewardToken[msg.sender] * DAOrewardAccount.accumulatedInput()) /
            totalRewardToken - DAOpaidOut[msg.sender];

reward = (190 *110) / 200 - 90 =  14.5E

and 14.5 < 10 so the transaction will fail.

This PR fix that the main DAO can retrieve this amount.

#### Workarround

1. Wait unitl more Ether is sended to the DAORewardToken
2. Send Ether from the main DAO to the DAORewardAccount in order to later retrieve it (Two proposals).



