### PR TITLE
SampleOffer: Prevent unauthorized value transfer

### DIFF
--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -106,6 +106,10 @@ contract SampleOffer {
         client = _newClient;
     }
 
+    function () {
+        throw; // this is a business contract, no donations
+    }
+
     // interface for Ethereum Computer
     function payOneTimeReward() returns(bool) {
         if (msg.value < deploymentReward)

--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -47,6 +47,9 @@ contract SampleOffer {
         _
     }
 
+    // Prevents methods from perfoming any value transfer
+    modifier noEther() {if (msg.value > 0) throw; _}
+
     function SampleOffer(
         address _contractor,
         address _client,
@@ -75,7 +78,7 @@ contract SampleOffer {
         isContractValid = true;
     }
 
-    function setDailyWithdrawLimit(uint _dailyWithdrawLimit) onlyClient {
+    function setDailyWithdrawLimit(uint _dailyWithdrawLimit) onlyClient noEther {
         if (_dailyWithdrawLimit >= minDailyWithdrawLimit)
             dailyWithdrawLimit = _dailyWithdrawLimit;
     }
@@ -94,15 +97,15 @@ contract SampleOffer {
             paidOut += amount;
     }
 
-    function setRewardDivisor(uint _rewardDivisor) onlyClient {
+    function setRewardDivisor(uint _rewardDivisor) onlyClient noEther {
         rewardDivisor = _rewardDivisor;
     }
 
-    function setDeploymentReward(uint _deploymentReward) onlyClient {
+    function setDeploymentReward(uint _deploymentReward) onlyClient noEther {
         deploymentReward = _deploymentReward;
     }
 
-    function updateClientAddress(DAO _newClient) onlyClient {
+    function updateClientAddress(DAO _newClient) onlyClient noEther {
         client = _newClient;
     }
 

--- a/tests/scenarios/proposal/run.py
+++ b/tests/scenarios/proposal/run.py
@@ -24,8 +24,6 @@ def count_token_votes(amounts, votes):
 def run(ctx):
     ctx.assert_scenario_ran('fuel')
 
-    minamount = 2  # is determined by the total costs + one time costs
-    amount = random.randint(minamount, sum(ctx.token_amounts))
     votes = create_votes_array(
         ctx.token_amounts,
         not ctx.args.proposal_fail,
@@ -37,7 +35,7 @@ def run(ctx):
         "dao_address": ctx.dao_addr,
         "offer_abi": ctx.offer_abi,
         "offer_address": ctx.offer_addr,
-        "offer_amount": amount,
+        "offer_amount": ctx.args.deploy_total_costs,
         "offer_desc": 'Test Proposal',
         "proposal_deposit": ctx.args.proposal_deposit,
         "transaction_bytecode": '0x2ca15122',  # solc --hashes SampleOffer.sol

--- a/tests/scenarios/sampleoffer_dailypayment/run.py
+++ b/tests/scenarios/sampleoffer_dailypayment/run.py
@@ -30,5 +30,6 @@ def run(ctx):
     ctx.execute(expected={
         "offer_daily_withdraw_limit": daily_limit_in_ether,
         "contractor_diff": daily_limit_in_ether,
-        "dao_rewardaccount_diff": pay_reward_amount
+        "dao_rewardaccount_diff": pay_reward_amount,
+        "sample_offer_no_donations": True
     })

--- a/tests/scenarios/sampleoffer_dailypayment/template.js
+++ b/tests/scenarios/sampleoffer_dailypayment/template.js
@@ -12,6 +12,13 @@ addToTest(
 );
 
 
+var offer_balance_before = eth.getBalance(offer.address);
+// also let's sneak in a check that SampleOffer does not accept random donations
+web3.eth.sendTransaction({from:eth.accounts[3], to:offer.address, value:web3.toWei(10), gas:24000});
+var offer_balance_after = eth.getBalance(offer.address);
+addToTest('sample_offer_no_donations', offer_balance_after.eq(offer_balance_before));
+
+
 // The DAO will now set the daily withdrawal limit
 var prop_id = attempt_proposal(
     dao, // DAO in question


### PR DESCRIPTION
- Add a fallback function to assert that none can send money to
  SampleOffer unless it's done during the `sign()`

- Add a test to assert that simply sending ether to the SampleOffer
  won't work

- Add a `noEther` modifier to all method of `SampleOffer` that should
  not transfer any Ether, to make sure the client can't send any extra
  money via any of them.

- Fix the proposal test by sending the exact amount.