### PR TITLE
Fix `getDailyPayment()` calculation

### DIFF
--- a/SampleOfferWithoutReward.sol
+++ b/SampleOfferWithoutReward.sol
@@ -92,6 +92,9 @@ contract SampleOfferWithoutRewards {
         if (msg.sender != contractor)
             throw;
         uint amount = (now - dateOfSignature + 1 days) / (1 days) * dailyWithdrawLimit - paidOut;
+        if (amount > this.balance) {
+            amount = this.balance;
+        }
         if (contractor.send(amount))
             paidOut += amount;
     }


### PR DESCRIPTION
- If we are at the end of the payment period and we can withdraw more
  than the balance, simply take the balance and not have the money stuck
  there forever.