### PR TITLE
SampleOffer: fix withdraw negative amount issue

### DIFF
--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -37,7 +37,7 @@ contract SampleOffer is SampleOfferWithoutReward {
             bytes32 _IPFSHashOfTheProposalDocument,
             uint _totalCosts,
             uint _oneTimeCosts,
-            uint _minDailyWithdrawLimit
+            uint128 _minDailyWithdrawLimit
         ) SampleOfferWithoutReward(
             _contractor,
             _client,
@@ -46,7 +46,7 @@ contract SampleOffer is SampleOfferWithoutReward {
             _oneTimeCosts,
             _minDailyWithdrawLimit) {
         }
-    
+
     // interface for Ethereum Computer
     function payOneTimeReward() returns(bool) {
         // client DAO should not be able to pay itself generating


### PR DESCRIPTION
This fixes the issue https://github.com/slockit/DAO/issues/171. Instread of remembering how much was payed out, it is remembered when the last payout was. Type type of withdraw limits has been also changed to uint128 to avoid overflow calculating the amount for the withdraw.