### PR TITLE
SampleOffer: Remove unneeded variable

### DIFF
--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -27,7 +27,6 @@ import "./SampleOfferWithoutReward.sol";
 
 contract SampleOffer is SampleOfferWithoutReward {
 
-    uint public rewardDivisor;
     uint public deploymentReward;
 
         function SampleOffer(


### PR DESCRIPTION
@CJentzsch: The DAO can't set any divisor fee anymore, right? So this variable is a forgotten remnant that should be removed, correct?