### PR TITLE
Sample offer quorum for firing

### DIFF
--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -36,14 +36,16 @@ contract SampleOffer is SampleOfferWithoutReward {
             bytes32 _IPFSHashOfTheProposalDocument,
             uint _totalCosts,
             uint _oneTimeCosts,
-            uint128 _minDailyWithdrawLimit
+            uint128 _minDailyWithdrawLimit,
+            uint _quorumForChange
         ) SampleOfferWithoutReward(
             _contractor,
             _client,
             _IPFSHashOfTheProposalDocument,
             _totalCosts,
             _oneTimeCosts,
-            _minDailyWithdrawLimit) {
+            _minDailyWithdrawLimit,
+            _quorumForChange) {
         }
 
     // interface for Ethereum Computer

--- a/SampleOfferWithoutReward.sol
+++ b/SampleOfferWithoutReward.sol
@@ -32,7 +32,128 @@ along with the DAO.  If not, see <http://www.gnu.org/licenses/>.
                 Contractor.
 */
 
-import "./DAO.sol";
+import "./ManagedAccount.sol";
+import "./Token.sol";
+import "./TokenCreation.sol";
+
+contract DAO is Token, TokenCreation {
+    uint constant creationGracePeriod = 40 days;
+    uint constant minProposalDebatePeriod = 2 weeks;
+    uint constant minSplitDebatePeriod = 1 weeks;
+    uint constant splitExecutionPeriod = 27 days;
+    uint constant quorumHalvingPeriod = 25 weeks;
+    uint constant executeProposalPeriod = 10 days;
+    uint constant maxDepositDivisor = 100;
+
+    Proposal[] public proposals;
+    uint public minQuorumDivisor;
+    uint public lastTimeMinQuorumMet;
+    address public curator;
+    mapping (address => bool) public allowedRecipients;
+    mapping (address => uint) public rewardToken;
+    uint public totalRewardToken;
+    ManagedAccount public rewardAccount;
+    ManagedAccount public DAOrewardAccount;
+    mapping (address => uint) public DAOpaidOut;
+    mapping (address => uint) public paidOut;
+    mapping (address => uint) public blocked;
+    uint public proposalDeposit;
+    uint sumOfProposalDeposits;
+
+    struct Proposal {
+        address recipient;
+        uint amount;
+
+        uint description;
+
+        uint votingDeadline;
+        bool open;
+        bool proposalPassed;
+        bytes32 proposalHash;
+        uint proposalDeposit;
+        bool newCurator;
+
+        uint splitData;
+
+        uint yea;
+        uint nay;
+
+        uint votedYes;
+
+        uint votedNo;
+
+        address creator;
+    }
+
+    struct SplitData {
+        uint splitBalance;
+        uint totalSupply;
+        uint rewardToken;
+        DAO newDAO;
+    }
+
+    modifier onlyTokenholders {}
+
+    function () returns (bool success);
+    function receiveEther() returns(bool);
+    function newProposal(
+        address _recipient,
+        uint _amount,
+        string _description,
+        bytes _transactionData,
+        uint _debatingPeriod,
+        bool _newCurator
+    ) onlyTokenholders returns (uint _proposalID);
+
+    function checkProposalCode(
+        uint _proposalID,
+        address _recipient,
+        uint _amount,
+        bytes _transactionData
+    ) constant returns (bool _codeChecksOut);
+    function vote(
+        uint _proposalID,
+        bool _supportsProposal
+    ) onlyTokenholders returns (uint _voteID);
+    function executeProposal(
+        uint _proposalID,
+        bytes _transactionData
+    ) returns (bool _success);
+    function splitDAO(
+        uint _proposalID,
+        address _newCurator
+    ) returns (bool _success);
+    function newContract(address _newContract);
+    function changeAllowedRecipients(address _recipient, bool _allowed) external returns (bool _success);
+    function changeProposalDeposit(uint _proposalDeposit) external;
+    function retrieveDAOReward(bool _toMembers) external returns (bool _success);
+    function getMyReward() returns(bool _success);
+    function withdrawRewardFor(address _account) internal returns (bool _success);
+    function transferWithoutReward(address _to, uint256 _amount) returns (bool success);
+    function transferFromWithoutReward(
+        address _from,
+        address _to,
+        uint256 _amount
+    ) returns (bool success);
+
+    function halveMinQuorum() returns (bool _success);
+    function numberOfProposals() constant returns (uint _numberOfProposals);
+    function getNewDAOAddress(uint _proposalID) constant returns (address _newDAO);
+    function isBlocked(address _account) internal returns (bool);
+    function unblockMe() returns (bool);
+
+    event ProposalAdded(
+        uint indexed proposalID,
+        address recipient,
+        uint amount,
+        bool newCurator,
+        string description
+    );
+    event Voted(uint indexed proposalID, bool position, address indexed voter);
+    event ProposalTallied(uint indexed proposalID, bool result, uint quorum);
+    event NewCurator(address indexed _newCurator);
+    event AllowedRecipientChanged(address indexed _recipient, bool _allowed);
+}
 
 contract SampleOfferWithoutReward {
 
@@ -123,7 +244,7 @@ contract SampleOfferWithoutReward {
         if (_proposalID > client.numberOfProposals()) {
             return false;
         }
-        var (r,a,v,o,proposalPassed, proposalHash,,, yea, nay,) = client.proposals(_proposalID);
+        var (,,,,,proposalPassed, proposalHash,,,, yea, nay,,,) = client.proposals(_proposalID);
         uint quorum = (yea + nay) * 100 / client.totalSupply();
         var txData = new bytes(36);
         txData[0] = 0xbf;

--- a/tests/scenarios/deploy/arguments.json
+++ b/tests/scenarios/deploy/arguments.json
@@ -24,6 +24,11 @@
     "description": "Edits the Offer contract to consider a period of X seconds as a day",
     "type":"int"
 },{
+    "name": "quorum_for_change",
+    "default": 50,
+    "description": "The quorum required to change DAO client or fire the contractor",
+    "type":"int"
+}, {
     "name": "proposal_deposit",
     "default": 20,
     "description": "The default proposal deposit for every proposal of the DAO",

--- a/tests/scenarios/deploy/run.py
+++ b/tests/scenarios/deploy/run.py
@@ -27,6 +27,7 @@ def run(ctx):
             "offer_onetime": ctx.args.deploy_onetime_costs,
             "offer_total": ctx.args.deploy_total_costs,
             "min_tokens_to_create": ctx.args.deploy_min_tokens_to_create,
+            "quorum_for_change": ctx.args.deploy_quorum_for_change,
             "default_proposal_deposit": ctx.args.deploy_proposal_deposit
         },
         cb_before_creation=calculate_closing_time

--- a/tests/scenarios/deploy/template.js
+++ b/tests/scenarios/deploy/template.js
@@ -39,6 +39,7 @@ var _daoCreatorContract = creatorContract.new(
                         web3.toWei($offer_total, "ether"), //total costs
                         web3.toWei($offer_onetime, "ether"), //one time costs
                         web3.toWei(1, "ether"), //min daily costs
+                        $quorum_for_change,
                         {
 	                        from: contractor,
 	                        data: '$offer_bin',

--- a/tests/scenarios/firecontractor/run.py
+++ b/tests/scenarios/firecontractor/run.py
@@ -8,7 +8,7 @@ scenario_description = (
 
 def run(ctx):
     ctx.assert_scenario_ran('proposal')
-    bytecode = calculate_bytecode('returnRemainingMoney')
+    bytecode = calculate_bytecode('returnRemainingEther', ("uint256", 2))
     ctx.create_js_file(substitutions={
         "dao_abi": ctx.dao_abi,
         "dao_address": ctx.dao_addr,

--- a/tests/scenarios/firecontractor/template.js
+++ b/tests/scenarios/firecontractor/template.js
@@ -13,6 +13,13 @@ var prop_id = attempt_proposal(
     false // whether it's a split proposal or not
 );
 
+console.log("TEST - proposal check: " + dao.checkProposalCode(
+    prop_id,
+    offer.address,
+    0,
+    "0xbf51f24d0000000000000000000000000000000000000000000000000000000000000002"
+));
+console.log("TEST2 - proposal hash " + dao.proposals(prop_id)[6]);
 
 console.log("Voting for the proposal to fire the contractor");
 for (i = 0; i < eth.accounts.length; i++) {
@@ -28,6 +35,7 @@ for (i = 0; i < eth.accounts.length; i++) {
 checkWork();
 addToTest('offer_balance_before', web3.fromWei(eth.getBalance(offer.address)));
 addToTest('dao_rewardaccount_before', web3.fromWei(eth.getBalance(dao.DAOrewardAccount())));
+console.log("Our proposal is: " + prop_id);
 
 setTimeout(function() {
     miner.stop();
@@ -40,6 +48,14 @@ setTimeout(function() {
         true, // should the proposal be closed after this call?
         true // should the proposal pass?
     );
+
+
+    console.log("TEST - GIVENPROPID " + offer.givenProposalID());
+    console.log("TEST - GIVENHASH: " + offer.givenHash());
+    console.log("TEST - GIVENYEA: " + offer.givenYea());
+    console.log("TEST - GIVENNAY: " + offer.givenNay());
+    console.log("TEST - CALCULATEDHASH: " + offer.calculatedHash());
+    console.log("TEST - CALCULATXDATA: " + offer.calculatedTXDATA());
 
     addToTest('offer_balance_after', web3.fromWei(eth.getBalance(offer.address)));
     addToTest('dao_rewardaccount_after', web3.fromWei(eth.getBalance(dao.DAOrewardAccount())));


### PR DESCRIPTION
### **Warning** In progress. Do not merge.

 This PR is currently hampered by [this](https://github.com/ethereum/solidity/issues/598) solidity compiler bug and will not work, until it's fixed.
---
### The problem

Firing the contractor, or changing the client can currently be done with the DAO's minimum quorum which is only 20% of all the voters. That could be considered inconvenient, even though any such proposals can also be downvoted.
### The solution

At the deployment of the offer, the proposal also has an argument `_quorumForChange` which is a number from 0 to 100 representing the percentage of quorum needed for the execution of the important functions.

Both `returnRemainingEther()` and `updateClientAddress()` will also take the `_proposalID` of the proposal that voted them in as an argument. Then the Offer contract can query the client DAO and see if the proposal got passed with a quorum as big as the required `quorumForChange`. If and only if that is the case they will be executed.

To properly achieve this, the `proposalHash`, the `yea` and the `nay` of the proposal have to be checked.
### Potential downsides of the approach

Passing the `_proposalID` as an argument to the proposal may be considered inconvenient. If someone else tries to put in a proposal to the DAO at the same block as you, you may end up with a different ID than you expected, and have to remake the proposal.

But I believe that the ability to impose specific quorum for contract-breaking changes such as changing the client or firing the contractor, is a benefit that far outweighs the aforementioned inconvenience.
---

**NOT READY YET - DO NOT MERGE**
