### PR TITLE
Replace autogenerated offer getters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ tests/sampleoffer_dailypayment.js
 tests/sampleoffer_daopayownrewards.js
 tests/sampleoffer_setrewardvars.js
 tests/sampleoffer_changeclient.js
+tests/sampleoffer_gettersvt.js
 tests/curator_halveminquorum_fueling.js
 
 # Ignore deployment related file

--- a/SampleOffer.sol
+++ b/SampleOffer.sol
@@ -27,8 +27,8 @@ import "./SampleOfferWithoutReward.sol";
 
 contract SampleOffer is SampleOfferWithoutReward {
 
-    uint public rewardDivisor;
-    uint public deploymentReward;
+    uint rewardDivisor;
+    uint deploymentReward;
 
     function SampleOffer(
         address _contractor,
@@ -52,6 +52,16 @@ contract SampleOffer is SampleOfferWithoutReward {
 
     function setDeploymentReward(uint _deploymentReward) onlyClient noEther {
         deploymentReward = _deploymentReward;
+    }
+
+    // non-value-transfer getters
+
+    function getRewardDivisor() noEther constant returns (uint) {
+        return rewardDivisor;
+    }
+
+    function getDeploymentReward() noEther constant returns (uint) {
+        return deploymentReward;
     }
 
     // interface for USN

--- a/SampleOfferWithoutReward.sol
+++ b/SampleOfferWithoutReward.sol
@@ -39,35 +39,35 @@ contract SampleOfferWithoutReward {
     // The total cost of the Offer. Exactly this amount is transfered from the
     // Client to the Offer contract when the Offer is signed by the Client.
     // Set once by the Offerer.
-    uint public totalCosts;
+    uint totalCosts;
 
     // Initial withdraw to the Contractor. It is done the moment the Offer is
     // signed.
     // Set once by the Offerer.
-    uint public oneTimeCosts;
+    uint oneTimeCosts;
 
     // The minimal daily withdraw limit that the Contractor accepts.
     // Set once by the Offerer.
-    uint128 public minDailyWithdrawLimit;
+    uint128 minDailyWithdrawLimit;
 
     // The amount of wei the Contractor has right to withdraw daily above the
     // initial withdraw. The Contractor does not have to do the withdraws every
     // day as this amount accumulates.
-    uint128 public dailyWithdrawLimit;
+    uint128 dailyWithdrawLimit;
 
     // The address of the Contractor.
-    address public contractor;
+    address contractor;
 
     // The hash of the Proposal/Offer document.
-    bytes32 public hashOfTheProposalDocument;
+    bytes32 hashOfTheProposalDocument;
 
     // The time of the last withdraw to the Contractor.
-    uint public lastPayment;
+    uint lastPayment;
 
-    uint public dateOfSignature;
-    DAO public client; // address of DAO
-    DAO public originalClient; // address of DAO who signed the contract
-    bool public isContractValid;
+    uint dateOfSignature;
+    DAO client; // address of DAO
+    DAO originalClient; // address of DAO who signed the contract
+    bool isContractValid;
 
     modifier onlyClient {
         if (msg.sender != address(client))
@@ -94,6 +94,51 @@ contract SampleOfferWithoutReward {
         oneTimeCosts = _oneTimeCosts;
         minDailyWithdrawLimit = _minDailyWithdrawLimit;
         dailyWithdrawLimit = _minDailyWithdrawLimit;
+    }
+
+    // non-value-transfer getters
+    function getTotalCosts() noEther constant returns (uint) {
+        return totalCosts;
+    }
+
+    function getOneTimeCosts() noEther constant returns (uint) {
+        return oneTimeCosts;
+    }
+
+    function getMinDailyWithdrawLimit() noEther constant returns (uint128) {
+        return minDailyWithdrawLimit;
+    }
+
+    function getDailyWithdrawLimit() noEther constant returns (uint128) {
+        return dailyWithdrawLimit;
+    }
+
+    function getContractor() noEther constant returns (address) {
+        return contractor;
+    }
+
+    function getHashOfTheProposalDocument() noEther constant returns (bytes32) {
+        return hashOfTheProposalDocument;
+    }
+
+    function getLastPayment() noEther constant returns (uint) {
+        return lastPayment;
+    }
+
+    function getDateOfSignature() noEther constant returns (uint) {
+        return dateOfSignature;
+    }
+
+    function getClient() noEther constant returns (DAO) {
+        return client;
+    }
+
+    function getOriginalClient() noEther constant returns (DAO) {
+        return originalClient;
+    }
+
+    function getIsContractValid() noEther constant returns (bool) {
+        return isContractValid;
     }
 
     function sign() {

--- a/tests/scenarios/firecontractor/template.js
+++ b/tests/scenarios/firecontractor/template.js
@@ -57,7 +57,7 @@ setTimeout(function() {
         )
     );
     addToTest('got_back_all_money', testMap['rewards_diff'].eq(testMap['offer_diff']));
-    addToTest('offer_contract_valid', offer.isContractValid());
+    addToTest('offer_contract_valid', offer.getIsContractValid());
 
     testResults();
 }, $debating_period * 1000);

--- a/tests/scenarios/proposal/template.js
+++ b/tests/scenarios/proposal/template.js
@@ -71,7 +71,7 @@ setTimeout(function() {
         'deposit_returned',
         testMap['creator_balance_after_execution'].sub(testMap['creator_balance_before']).lt(new BigNumber(100000000000000000))
     );
-    addToTest('offer_promise_valid', offer.isContractValid());
+    addToTest('offer_promise_valid', offer.getIsContractValid());
 
     testResults();
 }, $debating_period * 1000);

--- a/tests/scenarios/sampleoffer_changeclient/template.js
+++ b/tests/scenarios/sampleoffer_changeclient/template.js
@@ -43,8 +43,8 @@ setTimeout(function() {
         true // should the proposal pass?
     );
 
-    addToTest('offer_original_client', offer.originalClient());
-    addToTest('offer_client', offer.client());
+    addToTest('offer_original_client', offer.getOriginalClient());
+    addToTest('offer_client', offer.getClient());
 
     console.log("Add offer contract as allowed recipient for the Child DAO");
 child_dao.changeAllowedRecipients.sendTransaction('$offer_address', true, {from: child_curator, gas: 1000000});

--- a/tests/scenarios/sampleoffer_dailypayment/template.js
+++ b/tests/scenarios/sampleoffer_dailypayment/template.js
@@ -58,7 +58,7 @@ setTimeout(function() {
         true // should the proposal pass?
     );
 
-    addToTest('offer_daily_withdraw_limit', web3.fromWei(offer.dailyWithdrawLimit()));
+    addToTest('offer_daily_withdraw_limit', web3.fromWei(offer.getDailyWithdrawLimit()));
 
     addToTest('contractor_before', eth.getBalance(contractor));
     // now the contractor can attempt to withdraw some money and we should check that this
@@ -67,7 +67,7 @@ setTimeout(function() {
     offer.getDailyPayment.sendTransaction({from: contractor, gas: 100000});
     var withdrawTime = new BigNumber(Math.floor(Date.now() / 1000));
     checkWork();
-    var expectedWei = ((withdrawTime.sub(offer.dateOfSignature())).mul(offer.dailyWithdrawLimit()))
+    var expectedWei = ((withdrawTime.sub(offer.getDateOfSignature())).mul(offer.getDailyWithdrawLimit()))
         .div(new BigNumber($offer_payment_period));
     console.log("-->ExpectedWei: " + expectedWei);
     console.log("-->OfferBalanceAfter: " + web3.fromWei(eth.getBalance(offer.address)));
@@ -76,9 +76,9 @@ setTimeout(function() {
               bigDiff(testMap['contractor_after'], testMap['contractor_before'])
              );
     // check that the contractor gets the Wei expected, within a 0.1 Ether difference
-    addToTest('contractor_paid_expected',
-              testMap['contractor_diff'].sub(expectedWei).abs().lt(new BigNumber(100000000000000000))
-             );
+    var contractor_profit = testMap['contractor_diff'].sub(expectedWei).abs();
+    console.log("-->contractor_profit: " + contractor_profit);
+    addToTest('contractor_paid_expected', contractor_profit.lt(new BigNumber(100000000000000000)));
     testResults();
 }, $debating_period * 1000);
 console.log("Wait for end of debating period");

--- a/tests/scenarios/sampleoffer_gettersvt/run.py
+++ b/tests/scenarios/sampleoffer_gettersvt/run.py
@@ -1,0 +1,19 @@
+from utils import arr_str, calculate_bytecode
+import time
+
+scenario_description = (
+    """Test that the offer's contract can't receive any money through its
+ getter functions."""
+)
+
+
+def run(ctx):
+    ctx.assert_scenario_ran('proposal')
+    ctx.create_js_file(substitutions={
+        "offer_abi": ctx.offer_abi,
+        "offer_address": ctx.offer_addr,
+    })
+
+    ctx.execute(expected={
+        "sample_offer_no_donations": True,
+    })

--- a/tests/scenarios/sampleoffer_gettersvt/template.js
+++ b/tests/scenarios/sampleoffer_gettersvt/template.js
@@ -1,0 +1,30 @@
+var offer = web3.eth.contract($offer_abi).at('$offer_address');
+var offer_balance_before = eth.getBalance(offer.address);
+
+offer.getTotalCosts.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+offer.getOneTimeCosts.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+offer.getDailyWithdrawLimit.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+offer.getContractor.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+offer.getHashOfTheProposalDocument.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+offer.getLastPayment.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+offer.getDateOfSignature.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+offer.getOriginalClient.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+offer.getIsContractValid.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+offer.getRewardDivisor.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+offer.getDeploymentReward.sendTransaction({from:eth.accounts[0], value: web3.toWei(10), gas: 200000});
+checkWork();
+
+var offer_balance_after = eth.getBalance(offer.address);
+addToTest('sample_offer_no_donations', offer_balance_after.eq(offer_balance_before));
+testResults();
+

--- a/tests/scenarios/sampleoffer_setrewardvars/template.js
+++ b/tests/scenarios/sampleoffer_setrewardvars/template.js
@@ -71,8 +71,8 @@ setTimeout(function() {
     );
 
     // test that the variables are set appropriately
-    addToTest('offer_reward_divisor', offer.rewardDivisor());
-    addToTest('offer_deployment_reward', offer.deploymentReward());
+    addToTest('offer_reward_divisor', offer.getRewardDivisor());
+    addToTest('offer_deployment_reward', offer.getDeploymentReward());
 
     var actor = eth.accounts[0];
     // emulate a USN node with onetimerward payment smaller than the set deployment reward.


### PR DESCRIPTION
- Removed all autogenerated public getters by making all public
  variables non-public. The reason for this is that someone could
  explicitly create a value-transfer transaction for those getters and
  manage to send money to the contract. That should not be possible.

- Created new getters that obey the `noEther` rule.

- Update existing tests to use the new getters

- New tests that checks that all Offer getters block value transfer 

