### PR TITLE
Add transaction data to Proposal and ProposalAdded Event

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -112,8 +112,6 @@ contract DAOInterface {
         // True if quorum has been reached, the votes have been counted, and
         // the majority said yes
         bool proposalPassed;
-        // A hash to check validity of a proposal
-        bytes32 proposalHash;
         // Deposit in wei the creator added when submitting their proposal. It
         // is taken from the msg.value of a newProposal call.
         uint proposalDeposit;
@@ -131,6 +129,9 @@ contract DAOInterface {
         mapping (address => bool) votedNo;
         // Address of the shareholder who created the proposal
         address creator;
+        // transactionData to be passed as part of call to recipient upon
+        // proposal execution
+        bytes transactionData;
     }
 
     // Used only in the case of a newCurator proposal.
@@ -202,21 +203,6 @@ contract DAOInterface {
         bool _newCurator
     ) onlyTokenholders returns (uint _proposalID);
 
-    /// @notice Check that the proposal with the ID `_proposalID` matches the
-    /// transaction which sends `_amount` with data `_transactionData`
-    /// to `_recipient`
-    /// @param _proposalID The proposal ID
-    /// @param _recipient The recipient of the proposed transaction
-    /// @param _amount The amount of wei to be sent in the proposed transaction
-    /// @param _transactionData The data of the proposed transaction
-    /// @return Whether the proposal ID matches the transaction data or not
-    function checkProposalCode(
-        uint _proposalID,
-        address _recipient,
-        uint _amount,
-        bytes _transactionData
-    ) constant returns (bool _codeChecksOut);
-
     /// @notice Vote on proposal `_proposalID` with `_supportsProposal`
     /// @param _proposalID The proposal ID
     /// @param _supportsProposal Yes/No - support of the proposal
@@ -230,11 +216,9 @@ contract DAOInterface {
     /// `_transactionData` has been voted for or rejected, and executes the
     /// transaction in the case it has been voted for.
     /// @param _proposalID The proposal ID
-    /// @param _transactionData The data of the proposed transaction
     /// @return Whether the proposed transaction has been executed or not
     function executeProposal(
-        uint _proposalID,
-        bytes _transactionData
+        uint _proposalID
     ) returns (bool _success);
 
     /// @notice ATTENTION! I confirm to move my remaining ether to a new DAO
@@ -334,7 +318,8 @@ contract DAOInterface {
         address recipient,
         uint amount,
         bool newCurator,
-        string description
+        string description,
+        bytes transactionData
     );
     event Voted(uint indexed proposalID, bool position, address indexed voter);
     event ProposalTallied(uint indexed proposalID, bool result, uint quorum);
@@ -449,7 +434,7 @@ contract DAO is DAOInterface, Token, TokenCreation {
         p.recipient = _recipient;
         p.amount = _amount;
         p.description = _description;
-        p.proposalHash = sha3(_recipient, _amount, _transactionData);
+        p.transactionData = _transactionData;
         p.votingDeadline = now + _debatingPeriod;
         p.open = true;
         //p.proposalPassed = False; // that's default
@@ -466,21 +451,10 @@ contract DAO is DAOInterface, Token, TokenCreation {
             _recipient,
             _amount,
             _newCurator,
-            _description
+            _description,
+            _transactionData
         );
     }
-
-
-    function checkProposalCode(
-        uint _proposalID,
-        address _recipient,
-        uint _amount,
-        bytes _transactionData
-    ) noEther constant returns (bool _codeChecksOut) {
-        Proposal p = proposals[_proposalID];
-        return p.proposalHash == sha3(_recipient, _amount, _transactionData);
-    }
-
 
     function vote(
         uint _proposalID,
@@ -516,8 +490,7 @@ contract DAO is DAOInterface, Token, TokenCreation {
 
 
     function executeProposal(
-        uint _proposalID,
-        bytes _transactionData
+        uint _proposalID
     ) noEther returns (bool _success) {
 
         Proposal p = proposals[_proposalID];
@@ -535,10 +508,8 @@ contract DAO is DAOInterface, Token, TokenCreation {
         if (now < p.votingDeadline  // has the voting deadline arrived?
             // Have the votes been counted?
             || !p.open
-            || p.proposalPassed // anyone trying to call us recursively?
-            // Does the transaction code match the proposal?
-            || p.proposalHash != sha3(p.recipient, p.amount, _transactionData)) {
-
+	    // anyone trying to call us recursively?
+            || p.proposalPassed){
             throw;
         }
 
@@ -558,9 +529,9 @@ contract DAO is DAOInterface, Token, TokenCreation {
         uint quorum = p.yea + p.nay;
 
         // require 53% for calling newContract()
-        if (_transactionData.length >= 4 && _transactionData[0] == 0x68
-            && _transactionData[1] == 0x37 && _transactionData[2] == 0xff
-            && _transactionData[3] == 0x1e
+        if (p.transactionData.length >= 4 && p.transactionData[0] == 0x68
+            && p.transactionData[1] == 0x37 && p.transactionData[2] == 0xff
+            && p.transactionData[3] == 0x1e
             && quorum < minQuorum(actualBalance() + rewardToken[address(this)])) {
 
                 proposalCheck = false;
@@ -584,7 +555,7 @@ contract DAO is DAOInterface, Token, TokenCreation {
             // multiple times out of the DAO
             p.proposalPassed = true;
 
-            if (!p.recipient.call.value(p.amount)(_transactionData))
+            if (!p.recipient.call.value(p.amount)(p.transactionData))
                 throw;
 
             _success = true;

--- a/tests/jsutils.py
+++ b/tests/jsutils.py
@@ -122,7 +122,6 @@ function attempt_split(argdao, prop_id, user, new_curator, split_exec_period) {
 function attempt_execute_proposal(
     argdao,
     prop_id,
-    bytecode,
     prop_creator,
     expect_closed,
     expect_pass) {
@@ -136,7 +135,6 @@ function attempt_execute_proposal(
 
     argdao.executeProposal.sendTransaction(
         prop_id,
-        bytecode,
         {from: prop_creator, gas:4700000}
     );
     checkWork();

--- a/tests/scenarios/colmattack/template.js
+++ b/tests/scenarios/colmattack/template.js
@@ -68,7 +68,6 @@ setTimeout(function() {
         attempt_execute_proposal(
             dao, // target DAO
             attack_prop_id, // proposal ID
-            '', // transaction bytecode
             attacker, // proposal creator
             true, // should the proposal be closed after this call?
             true // should the proposal pass?

--- a/tests/scenarios/deposit/template.js
+++ b/tests/scenarios/deposit/template.js
@@ -28,7 +28,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         curator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?

--- a/tests/scenarios/depositnofunds/template.js
+++ b/tests/scenarios/depositnofunds/template.js
@@ -28,7 +28,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         curator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?

--- a/tests/scenarios/extrabalance/template.js
+++ b/tests/scenarios/extrabalance/template.js
@@ -33,7 +33,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         claim_prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         proposalCreator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?

--- a/tests/scenarios/firecontractor/template.js
+++ b/tests/scenarios/firecontractor/template.js
@@ -56,7 +56,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         bad_prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         proposalCreator, // proposal creator
         false, // should the proposal be closed after this call?
         false // should the proposal pass?
@@ -70,7 +69,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         proposalCreator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?

--- a/tests/scenarios/newcontract/template.js
+++ b/tests/scenarios/newcontract/template.js
@@ -40,7 +40,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         curator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?

--- a/tests/scenarios/newcontractfail/template.js
+++ b/tests/scenarios/newcontractfail/template.js
@@ -39,7 +39,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         curator, // proposal creator
         false, // should the proposal be closed after this call?
         false // should the proposal pass?

--- a/tests/scenarios/proposal/template.js
+++ b/tests/scenarios/proposal/template.js
@@ -54,7 +54,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         proposalCreator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?

--- a/tests/scenarios/rewards/template.js
+++ b/tests/scenarios/rewards/template.js
@@ -43,7 +43,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         curator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?

--- a/tests/scenarios/sampleoffer_changeclient/template.js
+++ b/tests/scenarios/sampleoffer_changeclient/template.js
@@ -37,7 +37,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         curator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?

--- a/tests/scenarios/sampleoffer_dailypayment/template.js
+++ b/tests/scenarios/sampleoffer_dailypayment/template.js
@@ -53,7 +53,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         proposalCreator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?

--- a/tests/scenarios/sampleoffer_setrewardvars/template.js
+++ b/tests/scenarios/sampleoffer_setrewardvars/template.js
@@ -57,7 +57,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         div_prop_id, // proposal ID
-        '$set_div_bytecode', // transaction bytecode
         proposalCreator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?
@@ -65,7 +64,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         deploy_prop_id, // proposal ID
-        '$set_deploy_bytecode', // transaction bytecode
         proposalCreator, // proposal creator
         true, // should the proposal be closed after this call?
         true // should the proposal pass?

--- a/tests/scenarios/singlesplit/template.js
+++ b/tests/scenarios/singlesplit/template.js
@@ -82,7 +82,6 @@ setTimeout(function() {
             attempt_execute_proposal(
                 newdao, // target DAO
                 new_prop_id, // proposal ID
-                '', // transaction bytecode
                 new_curator, // proposal creator
                 true, // should the proposal be closed after this call?
                 true // should the proposal pass?

--- a/tests/scenarios/stealextrabalance/template.js
+++ b/tests/scenarios/stealextrabalance/template.js
@@ -34,7 +34,6 @@ setTimeout(function() {
     attempt_execute_proposal(
         dao, // target DAO
         claim_prop_id, // proposal ID
-        '$transaction_bytecode', // transaction bytecode
         attacker, // proposal creator
         false, // should the proposal be closed after this call?
         false // should the proposal pass?


### PR DESCRIPTION
This commit solves issue #203. Currently it is difficult to see what code will be executed if a  proposal is passed. Adding transactionData to the Proposal struct and the ProposalAdded event solves this problem, and allows third party tools to display this data easily. Adding transactionData to the Proposal struct was  previously discussed  in the comments of issue #80. There seems to be no good reason why the transactionData is not contained with the Proposal struct. 
