### PR TITLE
Add checkVoteStatus to PFOffer.sol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ tests/sampleoffer_gettersvt.js
 tests/curator_halveminquorum_fueling.js
 tests/pfoffer.js
 tests/pfoffer_payment.js
+tests/pfoffer_checkvotestatus_fail.js
 
 # Ignore deployment related file
 deploy/code.js

--- a/PFOffer.sol
+++ b/PFOffer.sol
@@ -217,8 +217,6 @@ contract PFOffer {
 
     // The proposal will not accept the results of the vote if it wasn't able
     // to be sure that YEA was able to succeed 48 hours before the deadline
-    function checkVoteStatus() {
-        var (,,votingDeadline,,,,,,yea,nay,) = client.proposals(proposalID);
     function checkVoteStatus() noEther {
         var (,,,votingDeadline,,,,,,yea,nay,) = client.proposals(proposalID);
         uint quorum = (yea + nay) * 100 / client.totalSupply();

--- a/PFOffer.sol
+++ b/PFOffer.sol
@@ -30,6 +30,17 @@ along with the DAO.  If not, see <http://www.gnu.org/licenses/>.
   - Client:     the DAO that gives ether to the Contractor. It signs off
                 the Offer, can adjust daily withdraw limit or even fire the
                 Contractor.
+
+  -- Important Note For Compilation --
+  This contract also reads from the DAO's proposal struct array. There used to
+  be a solidity bug (https://github.com/ethereum/solidity/issues/598#issuecomment-224015639)
+  that is now fixed which would result in wrong values when reading from the
+  proposals array.
+
+  Use a solc that includes commit:  0a0fc04641787ce057a9fcc9e366ea898b1fd8d6
+  to be sure that the contract is compiled with the fix and that the proposals
+  member attributes are read correctly. This comment will be updated as soon
+  as the fix makes it into a solc release.
 */
 
 import "./DAO.sol";

--- a/PFOffer.sol
+++ b/PFOffer.sol
@@ -41,6 +41,9 @@ contract PFOffer {
     // Time before the end of the voting period after which
     // checkVoteStatus() can no longer be called
     uint constant voteStatusDeadline = 48 hours;
+    // The minQuorum for which to accept the voteStatus check and modify
+    // the wasApprovedBeforeDeadline flag
+    uint constant minQuorum = 15;
 
     // The total cost of the Offer. Exactly this amount is transfered from the
     // Client to the Offer contract when the Offer is signed by the Client.
@@ -227,7 +230,7 @@ contract PFOffer {
         }
         // If quorum is met and majority is for it then the prevote
         // check can be considered as succesfull
-        wasApprovedBeforeDeadline = (quorum > 20 && yea > nay);
+        wasApprovedBeforeDeadline = (quorum >= minQuorum && yea > nay);
     }
 
     // Change the client DAO by giving the new DAO's address

--- a/tests/scenarios/deploy/arguments.json
+++ b/tests/scenarios/deploy/arguments.json
@@ -28,6 +28,11 @@
     "default": 20,
     "description": "Edits the PFOffer contract to consider a period of X seconds as the payout freeze period",
     "type":"int"
+}, {
+    "name": "pfoffer_vote_status_deadline",
+    "default": 1,
+    "description": "Sets the VoteStatusDeadline of the PFOffer contract",
+    "type":"int"
 },{
     "name": "proposal_deposit",
     "default": 20,

--- a/tests/scenarios/deploy/deploy_pfoffer_template.js
+++ b/tests/scenarios/deploy/deploy_pfoffer_template.js
@@ -6,9 +6,7 @@ var _offerContract = offerContract.new(
     '0x0',  // This is a hash of the paper contract. Does not matter for testing
     web3.toWei($offer_total, "ether"), //total costs
     web3.toWei($offer_onetime, "ether"), //one time costs
-    web3.toWei(1, "ether"), //min daily costs,
-    1,// the proposal ID of PFOffer. We know that in our tests that test PFOffer it's
-      // going to be the first proposal.
+    web3.toWei(1, "ether"), //min daily costs
     {
 	    from: contractor,
 	    data: '$pfoffer_bin',

--- a/tests/scenarios/deploy/deploy_pfoffer_template.js
+++ b/tests/scenarios/deploy/deploy_pfoffer_template.js
@@ -6,7 +6,9 @@ var _offerContract = offerContract.new(
     '0x0',  // This is a hash of the paper contract. Does not matter for testing
     web3.toWei($offer_total, "ether"), //total costs
     web3.toWei($offer_onetime, "ether"), //one time costs
-    web3.toWei(1, "ether"), //min daily costs
+    web3.toWei(1, "ether"), //min daily costs,
+    1,// the proposal ID of PFOffer. We know that in our tests that test PFOffer it's
+      // going to be the first proposal.
     {
 	    from: contractor,
 	    data: '$pfoffer_bin',

--- a/tests/scenarios/pfoffer/run.py
+++ b/tests/scenarios/pfoffer/run.py
@@ -28,6 +28,8 @@ def run(ctx):
     )
 
     ctx.execute(expected={
+        "only_contractor_can_watch_proposal": True,
+        "proposal_succesfully_watched": True,
         "approved_before_deadline": True,
         "no_money_at_sign": True,
         "contract_valid": True,

--- a/tests/scenarios/pfoffer/run.py
+++ b/tests/scenarios/pfoffer/run.py
@@ -19,7 +19,8 @@ def run(ctx):
         "offer_amount": ctx.args.deploy_total_costs,
         "proposal_deposit": ctx.args.proposal_deposit,
         "transaction_bytecode": bytecode,
-        "debating_period": ctx.args.proposal_debate_seconds
+        "debating_period": ctx.args.proposal_debate_seconds,
+        "vote_status_deadline": ctx.args.deploy_pfoffer_vote_status_deadline
     })
     print(
         "Notice: Debate period is {} seconds so the test will wait "
@@ -27,6 +28,7 @@ def run(ctx):
     )
 
     ctx.execute(expected={
+        "approved_before_deadline": True,
         "no_money_at_sign": True,
         "contract_valid": True,
         "onetime_payment_failed": True

--- a/tests/scenarios/pfoffer/template.js
+++ b/tests/scenarios/pfoffer/template.js
@@ -17,6 +17,14 @@ var prop_id = attempt_proposal(
     false // whether it's a split proposal or not
 );
 
+// the contractor should now make the offer contract watch the proposal votes
+pfoffer.watchProposal.sendTransaction(prop_id, {from:curator, gas: 400000});
+checkWork();
+addToTest('only_contractor_can_watch_proposal', pfoffer.getProposalID() == 0);
+pfoffer.watchProposal.sendTransaction(prop_id, {from:contractor, gas: 400000});
+checkWork();
+addToTest('proposal_succesfully_watched', pfoffer.getProposalID().eq(prop_id));
+
 
 console.log("Vote on the proposals");
 for (i = 0; i < eth.accounts.length; i++) {

--- a/tests/scenarios/pfoffer/template.js
+++ b/tests/scenarios/pfoffer/template.js
@@ -31,6 +31,11 @@ for (i = 0; i < eth.accounts.length; i++) {
 }
 checkWork();
 
+//perform the vote status check
+pfoffer.checkVoteStatus.sendTransaction({from: curator, gas: 400000});
+checkWork();
+addToTest('approved_before_deadline', pfoffer.getWasApprovedBeforeDeadline());
+
 
 setTimeout(function() {
     miner.stop();

--- a/tests/scenarios/pfoffer_checkvotestatus_fail/run.py
+++ b/tests/scenarios/pfoffer_checkvotestatus_fail/run.py
@@ -23,5 +23,6 @@ def run(ctx):
     })
 
     ctx.execute(expected={
+        "proposal_succesfully_watched": True,
         "approved_before_deadline": False,
     })

--- a/tests/scenarios/pfoffer_checkvotestatus_fail/run.py
+++ b/tests/scenarios/pfoffer_checkvotestatus_fail/run.py
@@ -1,0 +1,27 @@
+from utils import calculate_bytecode
+
+scenario_description = (
+    "Work on a PFOFfer contract with a very big vote status deadline which "
+    "will guarantee failure of the checkVoteStatus() call due to the "
+    "aforementioned deadline. Check that the failure indeed happens."
+)
+
+
+def run(ctx):
+    ctx.assert_scenario_ran('fuel')
+    bytecode = calculate_bytecode('sign')
+    ctx.create_js_file(substitutions={
+        "dao_abi": ctx.dao_abi,
+        "dao_address": ctx.dao_address,
+        "pfoffer_abi": ctx.pfoffer_abi,
+        "pfoffer_address": ctx.pfoffer_address,
+        "offer_amount": ctx.args.deploy_total_costs,
+        "proposal_deposit": ctx.args.proposal_deposit,
+        "transaction_bytecode": bytecode,
+        "debating_period": ctx.args.proposal_debate_seconds,
+        "vote_status_deadline": ctx.args.deploy_pfoffer_vote_status_deadline
+    })
+
+    ctx.execute(expected={
+        "approved_before_deadline": False,
+    })

--- a/tests/scenarios/pfoffer_checkvotestatus_fail/template.js
+++ b/tests/scenarios/pfoffer_checkvotestatus_fail/template.js
@@ -1,0 +1,38 @@
+var dao = web3.eth.contract($dao_abi).at('$dao_address');
+var pfoffer = web3.eth.contract($pfoffer_abi).at('$pfoffer_address');
+
+console.log("Add pfoffer contract as allowed recipient");
+dao.changeAllowedRecipients.sendTransaction('$pfoffer_address', true, {from: curator, gas: 1000000});
+checkWork();
+
+var prop_id = attempt_proposal(
+    dao, // DAO in question
+    '$pfoffer_address', // recipient
+    proposalCreator, // proposal creator
+    $offer_amount, // proposal amount in ether
+    'PFOffer Description', // description
+    '$transaction_bytecode', //bytecode
+    $debating_period, // debating period
+    $proposal_deposit, // proposal deposit in ether
+    false // whether it's a split proposal or not
+);
+
+
+console.log("Vote on the proposals");
+for (i = 0; i < eth.accounts.length; i++) {
+    dao.vote.sendTransaction(
+        prop_id,
+        true,
+        {
+            from: eth.accounts[i],
+            gas: 4000000
+        }
+    );
+}
+checkWork();
+
+//perform the vote status check
+pfoffer.checkVoteStatus.sendTransaction({from: curator, gas: 400000});
+checkWork();
+addToTest('approved_before_deadline', pfoffer.getWasApprovedBeforeDeadline());
+testResults();

--- a/tests/scenarios/pfoffer_checkvotestatus_fail/template.js
+++ b/tests/scenarios/pfoffer_checkvotestatus_fail/template.js
@@ -17,6 +17,11 @@ var prop_id = attempt_proposal(
     false // whether it's a split proposal or not
 );
 
+// the contractor should now make the offer contract watch the proposal votes
+pfoffer.watchProposal.sendTransaction(prop_id, {from:contractor, gas: 400000});
+checkWork();
+addToTest('proposal_succesfully_watched', pfoffer.getProposalID().eq(prop_id));
+
 
 console.log("Vote on the proposals");
 for (i = 0; i < eth.accounts.length; i++) {

--- a/tests/test.py
+++ b/tests/test.py
@@ -200,7 +200,8 @@ class TestContext():
                 self.scenario_uses_extrabalance(),
                 self.args.scenario == "fuel_fail_extrabalance",
                 self.args.deploy_offer_payment_period,
-                self.args.deploy_pfoffer_payout_freeze_period
+                self.args.deploy_pfoffer_payout_freeze_period,
+                self.args.deploy_pfoffer_vote_status_deadline
             )
             # compile USNRewardPayout and all contracts it depends on
             usn = os.path.join(self.contracts_dir, "USNRewardPayOutCopy.sol")

--- a/tests/test.py
+++ b/tests/test.py
@@ -202,6 +202,8 @@ class TestContext():
                 self.args.deploy_offer_payment_period,
                 self.args.deploy_pfoffer_payout_freeze_period,
                 self.args.deploy_pfoffer_vote_status_deadline
+                if not ctx.args.scenario == "pfoffer_checkvotestatus_fail"
+                else ctx.args.proposal_debate_seconds - 1
             )
             # compile USNRewardPayout and all contracts it depends on
             usn = os.path.join(self.contracts_dir, "USNRewardPayOutCopy.sol")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -366,7 +366,8 @@ def edit_dao_source(
         normal_pricing,
         extra_balance_refund,
         offer_payment_period,
-        payout_freeze_period):
+        payout_freeze_period,
+        vote_status_deadline):
     with open(os.path.join(contracts_dir, 'DAO.sol'), 'r') as f:
         contents = f.read()
 
@@ -479,6 +480,11 @@ def edit_dao_source(
         contents,
         "payoutFreezePeriod",
         str(payout_freeze_period)
+    )
+    contents = re_replace_or_die(
+        contents,
+        "voteStatusDeadline",
+        str(vote_status_deadline)
     )
     with open(os.path.join(contracts_dir, 'PFOfferCopy.sol'), "w") as f:
         f.write(contents)


### PR DESCRIPTION
This PR is made to add the functionality of what @alexvandesande introduced in [his sample Offer contract](https://gist.github.com/alexvandesande/122c05a0f8a7108523aed29ae7ec92b1) as `protectFromAmbush()` to the Proposal Framework Offer contract located in this repository.

The name of the function is changed to `checkVoteStatus()`. At any point within `voteStatusDeadline` seconds before the end of the voting period anyone can call `checkVoteStatus()` to attempt and set the
`wasApprovedBeforeDeadline` flag.

This allows for a way to protect  against a last minute yes vote  by requiring the flag to be set to true at an earlier point of the voting deadline. The offer can not be signed without this flag being set.

Tests for the functionality and logic introduced by `checkVoteStatus()` are added and are passing.

**a note for the compilation of the contract**: You need a very recent version of solc. It needs to contain [this](https://github.com/ethereum/solidity/pull/624) fix for the [Dynamic Return Data Decoder](https://github.com/ethereum/solidity/issues/598#issuecomment-224015639) bug.