### PR TITLE
Protect against recursive withdrawRewardFor attack

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -744,9 +744,10 @@ contract DAO is DAOInterface, Token, TokenCreation {
 
         reward = rewardAccount.balance < reward ? rewardAccount.balance : reward;
 
+        paidOut[_account] += reward;
         if (!rewardAccount.payOut(_account, reward))
             throw;
-        paidOut[_account] += reward;
+
         return true;
     }
 


### PR DESCRIPTION
The DAO code is vulnerable to the [recursive call](http://vessenes.com/more-ethereum-attacks-race-to-empty-is-the-real-deal/) attack in the `withdrawRewardFor()` function. This fix should handle it for the next deployment of the DAO code.

A very big thank you to eththrowa from the [daohub forums](https://forum.daohub.org/t/bug-discovered-in-mkr-token-contract-also-affects-thedao-would-allow-users-to-steal-rewards-from-thedao-by-calling-recursively/4947) for spotting this.